### PR TITLE
Update comment that is automatically put into PR conversation

### DIFF
--- a/scripts/expo/commands/publishCodeReview.js
+++ b/scripts/expo/commands/publishCodeReview.js
@@ -27,7 +27,7 @@ async function commentOnGitHub(buildName, githubPullRequestId) {
   const issueUrl = `https://${env.GITHUB_USERNAME}:${env.GITHUB_TOKEN}@api.github.com/repos/${env.TRAVIS_REPO_SLUG}/issues/${githubPullRequestId}/comments`;
 
   const body = `
-  Please test these changes in [Expo](https://docs.expo.io/versions/latest/introduction/installation.html#mobile-client-expo-for-ios-and-android):
+  Please test these changes in [Expo](https://docs.expo.io/versions/latest/introduction/installation.html#mobile-client-expo-for-ios-and-android) after build has finished:
 
   ![QR Code](${qrUrl})
   `;


### PR DESCRIPTION
Reason: While PR is building, reviewer might be confused by old version of app.

It takes some time before build is finished, so I would like to avoid confusion by improving the comment (It already happened to me and you may forget this fact again)