### PR TITLE
Show region based on markers & navigate to selected marker

### DIFF
--- a/app/common/index.js
+++ b/app/common/index.js
@@ -18,7 +18,7 @@ export { default as TextInput } from './src/forms/TextInput';
 export { default as FullPageLoading } from './src/loaders/FullPageLoading';
 export { default as SimpleLoading } from './src/loaders/SimpleLoading';
 
-export { default as PriceMaker } from './src/map/PriceMarker';
+export { default as PriceMarker } from './src/map/PriceMarker';
 
 export { default as Large } from './src/text/Large';
 

--- a/app/hotels/package.json
+++ b/app/hotels/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@kiwicom/react-native-app-common": "^0",
+    "geolib": "2.0.24",
     "react-native-swiper": "^1.5.13"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2951,6 +2951,10 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+geolib@2.0.24:
+  version "2.0.24"
+  resolved "https://registry.yarnpkg.com/geolib/-/geolib-2.0.24.tgz#eb3d7fbc65f5ea3354a5af6054563ebe9f33e5f4"
+
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"


### PR DESCRIPTION
 - Compute region manually from markers so the right place is displayed from the beginning (to avoid initial zooming animation, e.g. Europe => CZ => Prague)
- after map is ready (=whole region is loaded), animate to the currently selected marker

Must come after #49 