### PR TITLE
Eslint: enable 'no-underscore-dangle' to unify naming

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,12 @@ module.exports = {
   },
   plugins: ['prettier', 'react', 'flowtype'],
   rules: {
+    'no-underscore-dangle': [
+      'error',
+      {
+        enforceInMethodNames: true,
+      },
+    ],
     'prettier/prettier': [
       'error',
       {

--- a/.flowconfig
+++ b/.flowconfig
@@ -41,7 +41,7 @@ app/core/config/flow-typed/
 [options]
 emoji=true
 module.system=haste
-munge_underscores=true
+munge_underscores=false
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
 module.name_mapper='^expo$' -> 'emptyObject'

--- a/app/common/src/Color.js
+++ b/app/common/src/Color.js
@@ -13,14 +13,14 @@ export default {
   // other colors
   // https://material.io/guidelines/style/color.html#color-color-palette
   grey: {
-    _100: '#f5f5f5',
-    _200: '#eeeeee',
-    _300: '#e0e0e0',
-    _400: '#bdbdbd',
-    _500: '#9e9e9e',
-    _600: '#757575',
-    _700: '#616161',
-    _800: '#424242',
-    _900: '#212121',
+    $100: '#f5f5f5',
+    $200: '#eeeeee',
+    $300: '#e0e0e0',
+    $400: '#bdbdbd',
+    $500: '#9e9e9e',
+    $600: '#757575',
+    $700: '#616161',
+    $800: '#424242',
+    $900: '#212121',
   },
 };

--- a/app/common/src/map/PriceMarker.js
+++ b/app/common/src/map/PriceMarker.js
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
   currency: {
-    color: Color.grey._700,
+    color: Color.grey.$700,
     fontSize: 12,
   },
   arrowBorder: {

--- a/app/core/src/components/authentication/EmailLoginForm.js
+++ b/app/core/src/components/authentication/EmailLoginForm.js
@@ -24,18 +24,18 @@ export default class SimpleLoginForm extends React.Component<Props, State> {
     loading: false,
   };
 
-  _handleEmailChange = text =>
+  handleEmailChange = (text: string) =>
     this.setState({
       username: text,
     });
 
-  _handlePasswordChange = text =>
+  handlePasswordChange = (text: string) =>
     this.setState({
       password: text,
     });
 
-  _handleFormSubmit = () =>
-    this._tryLogIn(
+  handleFormSubmit = () =>
+    this.tryLogIn(
       this.state.username,
       this.state.password,
       (response, errors) => {
@@ -47,7 +47,7 @@ export default class SimpleLoginForm extends React.Component<Props, State> {
       },
     );
 
-  _tryLogIn = (username: string, password: string, callback: Callback) => {
+  tryLogIn = (username: string, password: string, callback: Callback) => {
     this.setState({ loading: true });
     LoginMutation({ email: username, password }, (response, errors) => {
       this.setState({ loading: false });
@@ -58,20 +58,20 @@ export default class SimpleLoginForm extends React.Component<Props, State> {
   render = () => (
     <View>
       <TextInput
-        onChangeText={this._handleEmailChange}
+        onChangeText={this.handleEmailChange}
         keyboardType="email-address"
         placeholder="Email"
         value={this.state.username}
       />
       <TextInput
-        onChangeText={this._handlePasswordChange}
+        onChangeText={this.handlePasswordChange}
         placeholder="Password"
         secureTextEntry={true}
       />
       {this.state.loading ? (
         <Button title="Logging in..." />
       ) : (
-        <Button onPress={this._handleFormSubmit} title="Login!" />
+        <Button onPress={this.handleFormSubmit} title="Login!" />
       )}
     </View>
   );

--- a/app/core/src/screens/homepage/search/SearchHeaderForm.js
+++ b/app/core/src/screens/homepage/search/SearchHeaderForm.js
@@ -40,29 +40,29 @@ const SearchForm = class SearchForm extends React.Component<Props, State> {
     };
   }
 
-  _changeLocation = (location: 'from' | 'to', newLocation) =>
+  changeLocation = (location: 'from' | 'to', newLocation) =>
     this.setState(() => {
       this.props.onLocationChange(newLocation, location);
     });
 
-  _handleOriginFocusChange = ({ nativeEvent }: InputOnFocusEvent) =>
-    this._handleOriginTextChange(nativeEvent.text);
+  handleOriginFocusChange = ({ nativeEvent }: InputOnFocusEvent) =>
+    this.handleOriginTextChange(nativeEvent.text);
 
-  _handleOriginTextChange = (newOrigin: string) =>
-    this._changeLocation('from', newOrigin);
+  handleOriginTextChange = (newOrigin: string) =>
+    this.changeLocation('from', newOrigin);
 
-  _handleDestinationFocusChange = ({ nativeEvent }: InputOnFocusEvent) =>
-    this._handleDestinationTextChange(nativeEvent.text);
+  handleDestinationFocusChange = ({ nativeEvent }: InputOnFocusEvent) =>
+    this.handleDestinationTextChange(nativeEvent.text);
 
-  _handleDestinationTextChange = (newDestination: string) =>
-    this._changeLocation('to', newDestination);
+  handleDestinationTextChange = (newDestination: string) =>
+    this.changeLocation('to', newDestination);
 
-  _handleDatepickerChange = date =>
+  handleDatepickerChange = date =>
     this.setState({
       date: { from: date },
     });
 
-  _handleSubmitButton = () =>
+  handleSubmitButton = () =>
     this.props.onSend(
       this.props.fields.from,
       this.props.fields.to,
@@ -76,15 +76,15 @@ const SearchForm = class SearchForm extends React.Component<Props, State> {
       </View>
 
       <TextInput
-        onFocus={this._handleOriginFocusChange}
-        onChangeText={this._handleOriginTextChange}
+        onFocus={this.handleOriginFocusChange}
+        onChangeText={this.handleOriginTextChange}
         value={this.props.fields.from}
         placeholder="Where do you travel from?"
       />
 
       <TextInput
-        onFocus={this._handleDestinationFocusChange}
-        onChangeText={this._handleDestinationTextChange}
+        onFocus={this.handleDestinationFocusChange}
+        onChangeText={this.handleDestinationTextChange}
         style={{
           flex: 1,
           color: 'black',
@@ -96,12 +96,12 @@ const SearchForm = class SearchForm extends React.Component<Props, State> {
       />
 
       <DatePicker
-        onDateChange={this._handleDatepickerChange}
+        onDateChange={this.handleDatepickerChange}
         date={this.state.date.from}
       />
 
       {this.props.expanded && (
-        <Button onPress={this._handleSubmitButton} title="Find connections!" />
+        <Button onPress={this.handleSubmitButton} title="Find connections!" />
       )}
     </View>
   );

--- a/app/core/src/screens/searchResults/SearchResults.js
+++ b/app/core/src/screens/searchResults/SearchResults.js
@@ -25,7 +25,7 @@ export class SearchResultsWithoutData extends React.Component<Props, State> {
     loading: false,
   };
 
-  _loadMore = () => {
+  loadMore = () => {
     this.setState({ loading: true });
     const { relay } = this.props;
     if (!relay.hasMore() || relay.isLoading()) {
@@ -66,7 +66,7 @@ export class SearchResultsWithoutData extends React.Component<Props, State> {
           (this.state.loading ? (
             <Button title="Loading..." />
           ) : (
-            <Button onPress={this._loadMore} title="Load more!" />
+            <Button onPress={this.loadMore} title="Load more!" />
           ))}
       </ScrollView>
     );

--- a/app/core/src/screens/singleBooking/SingleBooking.js
+++ b/app/core/src/screens/singleBooking/SingleBooking.js
@@ -28,7 +28,7 @@ class SingleBooking extends React.Component<Props, State> {
     refreshing: false,
   };
 
-  _refetch = () => {
+  refetch = () => {
     this.setState({ refreshing: true }, () => {
       this.props.relay.refetch(
         v => v,
@@ -48,7 +48,7 @@ class SingleBooking extends React.Component<Props, State> {
    *
    * [departure, arrival, departure, arrival, ...]
    */
-  _prepareTimelineComponentsList = legs => {
+  prepareTimelineComponentsList = legs => {
     return [].concat(
       ...legs.map(leg => {
         if (leg) {
@@ -101,7 +101,7 @@ class SingleBooking extends React.Component<Props, State> {
           refreshControl={
             <RefreshControl
               refreshing={this.state.refreshing}
-              onRefresh={this._refetch}
+              onRefresh={this.refetch}
             />
           }
         >
@@ -109,7 +109,7 @@ class SingleBooking extends React.Component<Props, State> {
 
           <View style={{ marginTop: 15, marginBottom: 10 }}>
             <Timeline
-              componentsList={this._prepareTimelineComponentsList(legs)}
+              componentsList={this.prepareTimelineComponentsList(legs)}
             />
           </View>
 

--- a/app/core/src/services/assets/AssetsDownloader.js
+++ b/app/core/src/services/assets/AssetsDownloader.js
@@ -12,7 +12,7 @@ export default new class AssetsDownloader {
       return;
     }
 
-    const absoluteFileName = this._getAbsoluteFileName(url);
+    const absoluteFileName = this.getAbsoluteFileName(url);
 
     FileSystem.getInfoAsync(absoluteFileName).then(info => {
       if (info.exists) {
@@ -23,7 +23,7 @@ export default new class AssetsDownloader {
     });
   };
 
-  _getAbsoluteFileName = (url: string) => {
+  getAbsoluteFileName = (url: string) => {
     const parsedUrl = nodeUrl.parse(url);
     if (parsedUrl.pathname) {
       const fileName = parsedUrl.pathname.match(/[^/]+\.[^/]+/);

--- a/app/hotels/src/allHotels/AllHotels.js
+++ b/app/hotels/src/allHotels/AllHotels.js
@@ -40,7 +40,7 @@ export default class AllHotelsSearch extends React.Component<Props, State> {
     },
   };
 
-  _handleSearchChange = (search: SearchParametersType) => {
+  handleSearchChange = (search: SearchParametersType) => {
     this.setState({
       search: {
         latitude: search.latitude,
@@ -73,7 +73,7 @@ export default class AllHotelsSearch extends React.Component<Props, State> {
     const { search } = this.state;
     return (
       <View style={styles.wrapper}>
-        <SearchForm onChange={this._handleSearchChange} />
+        <SearchForm onChange={this.handleSearchChange} />
         {this.isReadyToSearch() && (
           <PublicApiRenderer
             query={graphql`

--- a/app/hotels/src/allHotels/SearchForm.js
+++ b/app/hotels/src/allHotels/SearchForm.js
@@ -39,7 +39,7 @@ const buttonStyles = StyleSheet.create({
     borderRadius: 0,
   },
   buttonText: {
-    color: Color.grey._900,
+    color: Color.grey.$900,
   },
 });
 
@@ -79,9 +79,9 @@ export default class SearchForm extends React.Component<Props, State> {
   /**
    * Submit form with the initial search parameters.
    */
-  componentDidMount = () => this._handleOnChange();
+  componentDidMount = () => this.handleOnChange();
 
-  _handleOnChange = () =>
+  handleOnChange = () =>
     this.props.onChange({
       latitude: this.state.latitude,
       longitude: this.state.longitude,
@@ -90,21 +90,21 @@ export default class SearchForm extends React.Component<Props, State> {
       roomsConfiguration: this.state.roomsConfiguration,
     });
 
-  _handleDestinationChange = destination => {
-    this.setState({ destination }, () => this._handleOnChange());
-  };
+  handleDestinationChange = (destination: string) =>
+    this.setState({ destination }, () => this.handleOnChange());
 
-  _handleCheckinChange = date => this._handleDateChange(date, 'checkin');
+  handleCheckinChange = (date: string) =>
+    this.handleDateChange(date, 'checkin');
 
-  _handleCheckoutChange = date => this._handleDateChange(date, 'checkout');
+  handleCheckoutChange = (date: string) =>
+    this.handleDateChange(date, 'checkout');
 
-  _handleDateChange = (date, type: 'checkin' | 'checkout') => {
-    this.setState({ [type]: date }, () => this._handleOnChange());
-  };
+  handleDateChange = (date: string, type: 'checkin' | 'checkout') =>
+    this.setState({ [type]: date }, () => this.handleOnChange());
 
-  _handleGuestsPress = () => {
+  handleGuestsPress = () => {
     // TODO Open popup with guests configuration
-    this._handleOnChange();
+    this.handleOnChange();
   };
 
   render = () => {
@@ -114,7 +114,7 @@ export default class SearchForm extends React.Component<Props, State> {
         <View style={styles.destination}>
           <TextInput
             value={this.state.destination}
-            onChangeText={this._handleDestinationChange}
+            onChangeText={this.handleDestinationChange}
             placeholder="Where do you go?"
           />
         </View>
@@ -123,18 +123,18 @@ export default class SearchForm extends React.Component<Props, State> {
             placeholder="Start date"
             format={DATE_FORMAT}
             date={this.state.checkin}
-            onDateChange={this._handleCheckinChange}
+            onDateChange={this.handleCheckinChange}
             style={styles.datePicker}
           />
           <DatePicker
             placeholder="End date"
             format={DATE_FORMAT}
             date={this.state.checkout}
-            onDateChange={this._handleCheckoutChange}
+            onDateChange={this.handleCheckoutChange}
             style={styles.datePicker}
           />
           <Button
-            onPress={this._handleGuestsPress}
+            onPress={this.handleGuestsPress}
             title={guests}
             styles={buttonStyles}
           />

--- a/app/hotels/src/filter/FilterButton.js
+++ b/app/hotels/src/filter/FilterButton.js
@@ -25,11 +25,11 @@ export default function FilterButton(props: Props) {
   const { title, isActive, icon, onPress } = props;
   const buttonStyles = {
     button: {
-      backgroundColor: isActive ? Color.grey._800 : Color.brand,
+      backgroundColor: isActive ? Color.grey.$800 : Color.brand,
       paddingLeft: isActive || !icon ? 10 : 0,
     },
     icon: {
-      backgroundColor: isActive ? Color.grey._700 : Color.brand,
+      backgroundColor: isActive ? Color.grey.$700 : Color.brand,
     },
   };
   return (

--- a/app/hotels/src/filter/FilterStripe.js
+++ b/app/hotels/src/filter/FilterStripe.js
@@ -38,7 +38,7 @@ export default class FilterStripe extends React.Component<{||}, State> {
     ],
   };
 
-  _handleButtonPress = (filterId: string) => () => {
+  handleButtonPress = (filterId: string) => () => {
     // TODO Open filter control
 
     const filters = this.state.filters;
@@ -53,13 +53,13 @@ export default class FilterStripe extends React.Component<{||}, State> {
     this.setState({ filters });
   };
 
-  _renderFilterButton = ({ title, icon, filter, isActive }: FilterType) => (
+  renderFilterButton = ({ title, icon, filter, isActive }: FilterType) => (
     <FilterButton
       key={filter}
       title={title}
       icon={icon}
       isActive={isActive}
-      onPress={this._handleButtonPress(filter)}
+      onPress={this.handleButtonPress(filter)}
     />
   );
 
@@ -72,7 +72,7 @@ export default class FilterStripe extends React.Component<{||}, State> {
           horizontal={true}
           showsHorizontalScrollIndicator={false}
         >
-          {filters.map(this._renderFilterButton)}
+          {filters.map(this.renderFilterButton)}
         </ScrollView>
       </View>
     );

--- a/app/relay/src/RelayQueryResponseCache.js
+++ b/app/relay/src/RelayQueryResponseCache.js
@@ -6,23 +6,23 @@ import JSONStableStringify from 'json-stable-stringify';
 export default class RelayQueryResponseCache {
   set = async (query: string, variables: Object, payload: Object) => {
     return await AsyncStorage.setItem(
-      this._getCacheKey(query, variables),
+      this.getCacheKey(query, variables),
       JSON.stringify(payload),
     );
   };
 
   get = async (query: string, variables: Object) => {
     return JSON.parse(
-      await AsyncStorage.getItem(this._getCacheKey(query, variables)),
+      await AsyncStorage.getItem(this.getCacheKey(query, variables)),
     );
   };
 
   remove = async (query: string, variables: Object) => {
     // await AsyncStorage.clear();
-    return await AsyncStorage.removeItem(this._getCacheKey(query, variables));
+    return await AsyncStorage.removeItem(this.getCacheKey(query, variables));
   };
 
-  _getCacheKey = (query: string, variables: Object): string => {
+  getCacheKey = (query: string, variables: Object): string => {
     return JSONStableStringify({ query, variables });
   };
 }


### PR DESCRIPTION
**Proposal**: I can see that underscore may be good visual clue providing information
about method being sort of private. But I have two arguments against:

1) Underscore method is not really private.
2) All React lifecycle methods are meant to be private but they are
not prefixed by the underscore which creates inconsistency and
additional confusion.

See: https://reactjs.org/docs/react-component.html#the-component-lifecycle
See: https://eslint.org/docs/rules/no-underscore-dangle
66646d5 