### PR TITLE
Common: add Slider component

### DIFF
--- a/app/common/index.js
+++ b/app/common/index.js
@@ -20,6 +20,7 @@ export { default as PartialFailure } from './src/errors/PartialFailure';
 export { default as DatePicker } from './src/forms/DatePicker';
 export { default as TextInput } from './src/forms/TextInput';
 export { default as NumberControl } from './src/forms/NumberControl';
+export { default as Slider } from './src/forms/Slider';
 
 export { default as NetworkImage } from './src/image/NetworkImage';
 

--- a/app/common/package.json
+++ b/app/common/package.json
@@ -4,6 +4,7 @@
   "private": false,
   "main": "index.js",
   "dependencies": {
+    "@ptomasroos/react-native-multi-slider": "ptomasroos/react-native-multi-slider",
     "react-native-image-progress": "^1.0.1",
     "react-native-modal": "^4.1.1"
   }

--- a/app/common/src/forms/Slider.js
+++ b/app/common/src/forms/Slider.js
@@ -1,0 +1,89 @@
+// @flow
+
+import * as React from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { OnLayout } from '@kiwicom/react-native-app-common';
+import MultiSlider from '@ptomasroos/react-native-multi-slider';
+
+import { POPUP_PADDING } from '../popup/Popup';
+import Color from '../Color';
+
+type Props = {|
+  onChange: (number[]) => void,
+  min: number,
+  max: number,
+  startValue: number,
+  endValue?: number,
+  step?: number,
+  // snapped?: boolean, FIXME https://github.com/ptomasroos/react-native-multi-slider/issues/49
+  style?: Object,
+|};
+
+type State = {|
+  width: number,
+|};
+
+export default class Slider extends React.Component<Props, State> {
+  state = {
+    width: 0,
+  };
+
+  onLayout = ({ nativeEvent }: OnLayout) => {
+    this.setState({ width: nativeEvent.layout.width });
+  };
+
+  render() {
+    const values = [this.props.startValue];
+    if (this.props.endValue) {
+      values.push(this.props.endValue);
+    }
+
+    return (
+      <View onLayout={this.onLayout} style={styles.sliderWrapper}>
+        <MultiSlider
+          values={values}
+          min={this.props.min}
+          max={this.props.max}
+          allowOverlap
+          selectedStyle={styles.selected}
+          sliderLength={this.state.width - 2 * POPUP_PADDING}
+          touchDimensions={{
+            height: 30,
+            width: 30,
+            borderRadius: 0,
+            slipDisplacement: 500,
+          }}
+          unselectedStyle={styles.unselected}
+          trackStyle={styles.track}
+          markerStyle={styles.marker}
+          containerStyle={[styles.container, this.props.style]}
+          onValuesChange={this.props.onChange}
+        />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  selected: { backgroundColor: Color.sun },
+  unselected: { backgroundColor: Color.grey.$400 },
+  track: { borderRadius: 5, height: 2 },
+  marker: {
+    height: 30,
+    width: 30,
+    borderRadius: 15,
+    backgroundColor: '#fff',
+    borderWidth: 0.5,
+    borderColor: Color.grey.$400,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.3,
+    shadowRadius: 2,
+  },
+  container: {
+    justifyContent: 'center',
+  },
+  sliderWrapper: {
+    paddingHorizontal: POPUP_PADDING,
+  },
+});

--- a/app/common/src/popup/Popup.js
+++ b/app/common/src/popup/Popup.js
@@ -13,6 +13,8 @@ type Props = {|
   onSave: () => void,
 |};
 
+export const POPUP_PADDING = 20;
+
 export default class Popup extends React.Component<Props> {
   onClose = () => this.props.onClose();
 
@@ -48,7 +50,7 @@ const styles = StyleSheet.create({
   content: {
     backgroundColor: '#fff',
     opacity: 1,
-    padding: 20,
+    padding: POPUP_PADDING,
   },
   button: {
     marginTop: 20,

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,6 +119,10 @@
     lodash "^4.17.4"
     react-native-vector-icons "4.4.2"
 
+"@ptomasroos/react-native-multi-slider@ptomasroos/react-native-multi-slider":
+  version "0.0.10"
+  resolved "https://codeload.github.com/ptomasroos/react-native-multi-slider/tar.gz/7398724080f8b49d121743cac89bc95304fc4483"
+
 "@segment/loosely-validate-event@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@segment/loosely-validate-event/-/loosely-validate-event-1.1.2.tgz#d77840999e3f7e43e74b3b0d43391c1526f793b8"


### PR DESCRIPTION
**You can try a slider in #122**

Known issues
* ~~it should detect device orientation changed and recalculate slider length (use `react-native-orientation` or store screen dimensions in redux and check on `mapStateToProps`)~~
* snapped (jump by steps) is broken in lib, but it's not needed right now (see: https://github.com/ptomasroos/react-native-multi-slider/issues/49)

---
Please check this before merging (do not delete this checklist):

- [x] it works in landscape and portrait mode
- [x] it uses `cacheConfig.force=true` if offline access doesn't make sense

  
  
  