### PR TITLE
Introduce new Icon component

### DIFF
--- a/app/common/index.js
+++ b/app/common/index.js
@@ -42,6 +42,7 @@ export { default as Stars } from './src/rating/Stars';
 
 export { default as Color } from './src/Color';
 export { default as Device } from './src/Device';
+export { default as Icon } from './src/Icon';
 export { default as Modal } from './src/Modal';
 export { default as Price } from './src/Price';
 export { default as WebView } from './src/WebView';

--- a/app/common/src/Color.js
+++ b/app/common/src/Color.js
@@ -63,10 +63,5 @@ export default {
   buttercup: '#eb9d08',
   sun: '#fbad18',
 
-  // FIXME: this should be part of the Icon component
-  icon: {
-    grey: ColorPalette.grey.$600,
-  },
-
   ...ColorPalette,
 };

--- a/app/common/src/Icon.js
+++ b/app/common/src/Icon.js
@@ -1,0 +1,25 @@
+// @flow
+
+import * as React from 'react';
+import { MaterialIcons } from '@expo/vector-icons';
+import { Color } from '@kiwicom/react-native-app-common';
+
+type Props = {|
+  name: string,
+  size: number,
+  color?: string,
+  style?: Object,
+|};
+
+const defaults = {
+  color: Color.grey.$600,
+};
+
+/**
+ * Currently only supported package is "MaterialIcons".
+ * @see https://material.io/icons/
+ */
+export default function Icon(props: Props) {
+  const newProps = { ...defaults, ...props };
+  return <MaterialIcons {...newProps} />;
+}

--- a/app/common/src/buttons/Button.js
+++ b/app/common/src/buttons/Button.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { MaterialIcons } from '@expo/vector-icons';
+import { Icon } from '@kiwicom/react-native-app-common';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import defaultsDeep from 'lodash/defaultsDeep';
 
@@ -27,7 +27,7 @@ export default function Button(props: Props) {
     <View style={[styles.buttonWrapper, additionalStyles.buttonWrapper]}>
       {props.icon && (
         <View style={[styles.icon, additionalStyles.icon]}>
-          <MaterialIcons {...defaultsDeep(props.icon, defaultIconProps)} />
+          <Icon {...defaultsDeep(props.icon, defaultIconProps)} />
         </View>
       )}
       <View style={[styles.button, additionalStyles.button]}>
@@ -51,7 +51,6 @@ export default function Button(props: Props) {
 
 const defaultIconProps = {
   size: 20,
-  color: '#fff',
 };
 
 function createStyles(iconAvailable) {

--- a/app/common/src/forms/NumberControl.js
+++ b/app/common/src/forms/NumberControl.js
@@ -1,10 +1,9 @@
 // @flow
 
 import * as React from 'react';
-import { MaterialIcons } from '@expo/vector-icons';
+import { Icon } from '@kiwicom/react-native-app-common';
 import { View, StyleSheet, Text } from 'react-native';
 
-import Color from '../Color';
 import IncrementDecrementButtons from '../buttons/IncrementDecrementButtons';
 
 type Props = {|
@@ -25,7 +24,7 @@ export default class NumberControl extends React.Component<Props> {
   render = () => (
     <View style={[styles.control, this.props.style]}>
       {this.props.icon && (
-        <MaterialIcons name={this.props.icon} size={20} style={styles.icon} />
+        <Icon name={this.props.icon} size={20} style={styles.icon} />
       )}
       <Text style={styles.label}>{this.props.label}</Text>
       <Text style={styles.number}>{this.props.number}</Text>
@@ -46,7 +45,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   icon: {
-    color: Color.icon.grey,
     marginRight: 8,
   },
   label: {

--- a/app/common/src/forms/TextInput.js
+++ b/app/common/src/forms/TextInput.js
@@ -1,10 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { MaterialIcons } from '@expo/vector-icons';
+import { Icon } from '@kiwicom/react-native-app-common';
 import { TextInput as OriginalTextInput, View } from 'react-native';
-
-import Color from '../Color';
 
 export const styles = {
   input: {
@@ -35,12 +33,7 @@ export default function TextInput(props: Props) {
   return (
     <View style={styles.wrapper}>
       {props.iconName && (
-        <MaterialIcons
-          name={props.iconName}
-          size={20}
-          color={Color.icon.grey}
-          style={styles.icon}
-        />
+        <Icon name={props.iconName} size={20} style={styles.icon} />
       )}
       <OriginalTextInput
         underlineColorAndroid="transparent"

--- a/app/common/src/map/DropMarker.js
+++ b/app/common/src/map/DropMarker.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { Icon } from '@kiwicom/react-native-app-common';
 
 import Color from '../Color';
 
@@ -25,8 +25,8 @@ type Props = {|
  */
 export default function DropMarker({ size = 50 }: Props) {
   return (
-    <MaterialCommunityIcons
-      name="map-marker"
+    <Icon
+      name="place"
       size={size}
       color={Color.brand}
       style={{ position: 'absolute', left: -size / 2, top: -size }}

--- a/app/common/src/map/__tests__/__snapshots__/DropMarker.test.js.snap
+++ b/app/common/src/map/__tests__/__snapshots__/DropMarker.test.js.snap
@@ -2,9 +2,8 @@
 
 exports[`calculates the offsets base on icon size 1`] = `
 <Icon
-  allowFontScaling={false}
   color="#0097a9"
-  name="map-marker"
+  name="place"
   size={50}
   style={
     Object {
@@ -18,9 +17,8 @@ exports[`calculates the offsets base on icon size 1`] = `
 
 exports[`calculates the offsets base on icon size 2`] = `
 <Icon
-  allowFontScaling={false}
   color="#0097a9"
-  name="map-marker"
+  name="place"
   size={100}
   style={
     Object {

--- a/app/core/src/screens/hotels/AllHotelsNavigationScreen.js
+++ b/app/core/src/screens/hotels/AllHotelsNavigationScreen.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { TouchableOpacity } from 'react-native';
 import { AllHotels } from '@kiwicom/react-native-app-hotels';
-import { Ionicons } from '@expo/vector-icons';
+import { Icon } from '@kiwicom/react-native-app-common';
 
 import type { Navigation } from '../../types/Navigation';
 import type {
@@ -40,7 +40,7 @@ class AllHotelsNavigationScreen extends React.Component<Props> {
           style={{ marginHorizontal: 10 }}
           onPress={goToAllHotelsMap}
         >
-          <Ionicons name="md-map" size={30} color="#fff" />
+          <Icon name="map" size={30} color="#fff" />
         </TouchableOpacity>
       ),
     };

--- a/app/hotels/src/allHotels/searchForm/Guests.js
+++ b/app/hotels/src/allHotels/searchForm/Guests.js
@@ -64,7 +64,6 @@ export default class Guests extends React.Component<Props, State> {
           styles={buttonStyles}
           icon={{
             name: 'people',
-            color: Color.icon.grey,
           }}
         />
         <Popup

--- a/app/hotels/src/allHotels/searchForm/__tests__/__snapshots__/Guests.test.js.snap
+++ b/app/hotels/src/allHotels/searchForm/__tests__/__snapshots__/Guests.test.js.snap
@@ -5,7 +5,6 @@ exports[`Guests Render all inputs 1`] = `
   <Button
     icon={
       Object {
-        "color": "#757575",
         "name": "people",
       }
     }

--- a/app/hotels/src/filter/FilterButton.js
+++ b/app/hotels/src/filter/FilterButton.js
@@ -15,7 +15,7 @@ type Props = {
   title: string,
   icon?: {|
     name: string,
-    type?: string,
+    color?: string,
   |},
   isActive: boolean,
   onPress: () => void,

--- a/app/hotels/src/filter/price/PriceFilter.js
+++ b/app/hotels/src/filter/price/PriceFilter.js
@@ -39,7 +39,7 @@ export default class PriceFilter extends React.Component<Props, State> {
       <View>
         <FilterButton
           title="price"
-          icon={{ name: 'attach-money' }}
+          icon={{ name: 'attach-money', color: '#fff' }}
           isActive={false}
           onPress={this.handlePopupToggle}
         />

--- a/app/hotels/src/filter/stars/StarsCheckbox.js
+++ b/app/hotels/src/filter/stars/StarsCheckbox.js
@@ -2,8 +2,7 @@
 
 import * as React from 'react';
 import { View, Text, StyleSheet, TouchableWithoutFeedback } from 'react-native';
-import { MaterialIcons } from '@expo/vector-icons';
-import { Color, Stars } from '@kiwicom/react-native-app-common';
+import { Color, Stars, Icon } from '@kiwicom/react-native-app-common';
 
 type Props = {|
   onPress: () => void,
@@ -28,7 +27,7 @@ export default function StarsCheckbox(props: Props) {
         </View>
         {props.isChecked && (
           <View style={styles.check}>
-            <MaterialIcons name="check" size={26} color={Color.brand} />
+            <Icon name="check" size={26} color={Color.brand} />
           </View>
         )}
       </View>

--- a/app/hotels/src/filter/stars/StarsFilter.js
+++ b/app/hotels/src/filter/stars/StarsFilter.js
@@ -33,7 +33,7 @@ export default class StarsFilter extends React.Component<Props, State> {
       <View>
         <FilterButton
           title="stars"
-          icon={{ name: 'star' }}
+          icon={{ name: 'star', color: '#fff' }}
           isActive={false}
           onPress={this.handlePopupToggle}
         />

--- a/app/hotels/src/filter/stars/__tests__/__snapshots__/StarsCheckbox.test.js.snap
+++ b/app/hotels/src/filter/stars/__tests__/__snapshots__/StarsCheckbox.test.js.snap
@@ -51,7 +51,6 @@ exports[`StarsCheckbox render checked 1`] = `
       }
     >
       <Icon
-        allowFontScaling={false}
         color="#0097a9"
         name="check"
         size={26}

--- a/app/hotels/src/map/Address.js
+++ b/app/hotels/src/map/Address.js
@@ -3,8 +3,7 @@
 import * as React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { StyleSheet, View, Text } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
-import { Color } from '@kiwicom/react-native-app-common';
+import { Color, Icon } from '@kiwicom/react-native-app-common';
 
 import type { Address as AddressData } from './__generated__/Address.graphql';
 
@@ -39,7 +38,7 @@ class Address extends React.Component<Props> {
     return (
       <View style={styles.container}>
         <View style={styles.mapIcon}>
-          <Ionicons name="md-map" size={24} color={Color.brand} />
+          <Icon name="map" size={24} color={Color.brand} />
         </View>
         <View style={styles.content}>
           <Text style={styles.header}>Address</Text>


### PR DESCRIPTION
This wraps `@expo/vector-icons` package and it will help us to do future
 changes easily. We currently support only icons from material design
 because these are the icons used in the design (only).

 Closes: https://github.com/kiwicom/react-native-app/issues/94


---
Please check this before merging (do not delete this checklist):

- [x] it works in landscape and portrait mode
- [x] it uses `cacheConfig.force=true` if offline access doesn't make sense

  