### PR TITLE
Allow to hide the partial error message

### DIFF
--- a/app/common/src/errors/PartialFailure.js
+++ b/app/common/src/errors/PartialFailure.js
@@ -1,30 +1,73 @@
 // @flow
 
 import * as React from 'react';
-import { Text, View, StyleSheet } from 'react-native';
+import { Text, View, StyleSheet, TouchableOpacity } from 'react-native';
 import { Color } from '@kiwicom/react-native-app-common';
+import { Icon } from '@kiwicom/react-native-app-common';
 
 type Props = {|
   children: React.Node,
 |};
 
-export default function PartialFailure({ children }: Props) {
-  const style = createStyle();
-  return [
-    children,
-    <View key="warning" style={style.container}>
-      <Text>
-        Some parts of the page may be missing due to partial server error.
-      </Text>
-    </View>,
-  ];
+type State = {|
+  dismissed: boolean,
+|};
+
+export default class PartialFailure extends React.Component<Props, State> {
+  state = {
+    dismissed: false,
+  };
+
+  toggle = () => {
+    this.setState(({ dismissed }) => ({
+      dismissed: !dismissed,
+    }));
+  };
+
+  render() {
+    const { children } = this.props;
+    const { dismissed } = this.state;
+    const style = createStyle();
+
+    if (dismissed) {
+      return [
+        children,
+        <TouchableOpacity
+          key="dismissed"
+          style={style.dismissed}
+          accessibilityLabel="Show warning"
+          onPress={this.toggle}
+        >
+          <Icon name="warning" size={20} />
+        </TouchableOpacity>,
+      ];
+    } else {
+      return [
+        children,
+        <View key="warning" style={style.container}>
+          <View style={style.message}>
+            <Text>
+              Some parts of the page may be missing due to partial server error.
+            </Text>
+          </View>
+          <TouchableOpacity
+            accessibilityLabel="Hide warning"
+            onPress={this.toggle}
+          >
+            <Icon name="close" size={20} />
+          </TouchableOpacity>
+        </View>,
+      ];
+    }
+  }
 }
 
 function createStyle() {
   return StyleSheet.create({
     container: {
       flexDirection: 'row',
-      justifyContent: 'center',
+      flex: 1,
+      alignItems: 'center',
       position: 'absolute',
       left: 0,
       right: 0,
@@ -32,6 +75,19 @@ function createStyle() {
       backgroundColor: Color.red.$100,
       paddingVertical: 5,
       paddingHorizontal: 10,
+    },
+    message: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    dismissed: {
+      position: 'absolute',
+      right: 0,
+      bottom: 0,
+      backgroundColor: Color.red.$100,
+      padding: 5,
+      borderTopLeftRadius: 5,
     },
   });
 }

--- a/app/common/src/errors/__tests__/PartialFailure.test.js
+++ b/app/common/src/errors/__tests__/PartialFailure.test.js
@@ -1,0 +1,16 @@
+// @flow
+
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+
+import PartialFailure from '../PartialFailure';
+
+it('renders failure and its children', () => {
+  expect(
+    renderer.create(
+      <PartialFailure>
+        <div>Some content</div>
+      </PartialFailure>,
+    ),
+  ).toMatchSnapshot();
+});

--- a/app/common/src/errors/__tests__/__snapshots__/PartialFailure.test.js.snap
+++ b/app/common/src/errors/__tests__/__snapshots__/PartialFailure.test.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders failure and its children 1`] = `
+Array [
+  <div>
+    Some content
+  </div>,
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#ffcdd2",
+        "bottom": 0,
+        "flex": 1,
+        "flexDirection": "row",
+        "left": 0,
+        "paddingHorizontal": 10,
+        "paddingVertical": 5,
+        "position": "absolute",
+        "right": 0,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "center",
+        }
+      }
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+      >
+        Some parts of the page may be missing due to partial server error.
+      </Text>
+    </View>
+    <View
+      accessibilityComponentType={undefined}
+      accessibilityLabel="Hide warning"
+      accessibilityTraits={undefined}
+      accessible={true}
+      collapsable={undefined}
+      hitSlop={undefined}
+      isTVSelectable={true}
+      nativeID={undefined}
+      onLayout={undefined}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "opacity": 1,
+        }
+      }
+      testID={undefined}
+      tvParallaxProperties={undefined}
+    >
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        ellipsizeMode="tail"
+      />
+    </View>
+  </View>,
+]
+`;


### PR DESCRIPTION
Close #137 

To test this feature, go to QueryRenderer.js and replace `if (this.partialError)` with `if (true)`.

# Portrait Mode

![image](https://user-images.githubusercontent.com/1473642/34730708-7fb050f4-f560-11e7-89e6-07236d3c19e6.png)

# Landscape Mode

![image](https://user-images.githubusercontent.com/1473642/34730663-5d206768-f560-11e7-8a15-cbd3c84f7ebb.png)


---
Please check this before merging (do not delete this checklist):

- [ ] it works in landscape and portrait mode
- [ ] it uses `cacheConfig.force=true` if offline access doesn't make sense
