### PR TITLE
Fix guests age after first save

### DIFF
--- a/app/hotels/src/allHotels/searchForm/guests/ChildrenAgesControl.js
+++ b/app/hotels/src/allHotels/searchForm/guests/ChildrenAgesControl.js
@@ -14,8 +14,8 @@ type Props = {|
 
 export default class ChildrenAgesControl extends React.Component<Props> {
   handleAgeChange = (index: number) => (age: number) => {
-    const { childrenAges } = this.props;
-    childrenAges[index].age = age;
+    const childrenAges = [...this.props.childrenAges];
+    childrenAges[index] = { age };
     this.props.onChange(childrenAges);
   };
 

--- a/app/hotels/src/allHotels/searchForm/guests/__tests__/ChildrenAgesControl.test.js
+++ b/app/hotels/src/allHotels/searchForm/guests/__tests__/ChildrenAgesControl.test.js
@@ -1,0 +1,37 @@
+// @flow
+
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+import { AgePicker } from '@kiwicom/react-native-app-common';
+
+import ChildrenAgesControl from '../ChildrenAgesControl';
+import AgeControl from '../AgeControl';
+
+const renderControl = (onChange: Function) => {
+  // This test covers fixed age change handler.
+  // Handler modified props and still would passed without freezed props.
+  // (That's why it worked in Expo and test, but not anymore in pure RN).
+  // Therefore I freeze props to be sure it would fail in bad cause and pass in fixed cause.
+  const age = Object.freeze({ age: 1 });
+  const childrenAges = [age];
+  return renderer.create(
+    <ChildrenAgesControl onChange={onChange} childrenAges={childrenAges} />,
+  );
+};
+
+it('age picker handler should change proper child age', () => {
+  expect.assertions(2);
+
+  const onChange = jest.fn();
+  const testRenderer = renderControl(onChange);
+  const testInstance = testRenderer.root;
+
+  // Initial age should be 1
+  const ageControl = testInstance.findByType(AgeControl);
+  expect(ageControl.props.age).toBe(1);
+
+  // Pick age = 2
+  const agePicker = testInstance.findByType(AgePicker);
+  agePicker.props.onChange(2);
+  expect(onChange).toBeCalledWith([{ age: 2 }]);
+});


### PR DESCRIPTION
Closes #130

---
Please check this before merging (do not delete this checklist):

- [x] it works in landscape and portrait mode
- [x] it uses `cacheConfig.force=true` if offline access doesn't make sense
