### PR TITLE
Redux: expose 'connect' function

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,13 @@ import HotelsReducer from './src/HotelsReducer';
 injectAsyncReducer(store, 'hotels', HotelsReducer);
 ```
 
-We currently do not officially support calling actions on reducers outside of one package. This means that you should always work with actions and reducers from `HotelReducer`. This should be in most of the scenarios good enough.
+We currently **do not** officially support calling actions on reducers outside of one package. This means that you should always work with actions and reducers from `HotelReducer`. This should be in most of the scenarios good enough. You must use `connect` function from `@kiwicom/react-native-app-redux` package in order to connect React component to the Redux store:
+
+```js
+import { connect } from '@kiwicom/react-native-app-redux';
+
+export default connect(select, actions)(ComponentWithoutStore);
+```
 
 ## Offline first
 

--- a/app/core/package.json
+++ b/app/core/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@kiwicom/react-native-app-common": "^0",
     "@kiwicom/react-native-app-hotels": "^0",
+    "@kiwicom/react-native-app-redux": "^0",
     "@kiwicom/react-native-app-relay": "^0",
     "idx": "^2.2.0",
     "json-stable-stringify": "^1.0.1",

--- a/app/core/src/components/authentication/Logout.js
+++ b/app/core/src/components/authentication/Logout.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '@kiwicom/react-native-app-redux';
 import { LinkButton } from '@kiwicom/react-native-app-common';
 
 type Props = {|

--- a/app/core/src/components/relay/PrivateApiRenderer.js
+++ b/app/core/src/components/relay/PrivateApiRenderer.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '@kiwicom/react-native-app-redux';
 import {
   PrivateApiRenderer as PrivateApiRendererOriginal,
   type QueryRendererProps,

--- a/app/core/src/screens/hotels/AllHotelsMapNavigationScreen.js
+++ b/app/core/src/screens/hotels/AllHotelsMapNavigationScreen.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '@kiwicom/react-native-app-redux';
 import { AllHotelsMap } from '@kiwicom/react-native-app-hotels';
 
 import type { Navigation } from '../../types/Navigation';

--- a/app/core/src/screens/hotels/AllHotelsNavigationScreen.js
+++ b/app/core/src/screens/hotels/AllHotelsNavigationScreen.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '@kiwicom/react-native-app-redux';
 import { TouchableOpacity } from 'react-native';
 import { AllHotels } from '@kiwicom/react-native-app-hotels';
 import { Icon } from '@kiwicom/react-native-app-common';

--- a/app/redux/index.js
+++ b/app/redux/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { createStore, type Store, type Reducer } from 'redux';
+import { connect } from 'react-redux';
 import { persistStore, persistCombineReducers } from 'redux-persist';
 import storage from 'redux-persist/es/storage';
 
@@ -31,4 +32,4 @@ const persistor = persistStore(store);
 
 store.asyncReducers = {};
 
-export { persistor, store };
+export { persistor, store, connect };


### PR DESCRIPTION
This will allow connection to the Redux store from every component you
want. It's necessary to use 'react-native-app-redux' package to make
sure everything works. Redux itself should never be used directly
(except our wrapper package of course).


---
Please check this before merging (do not delete this checklist):

- [x] it works in landscape and portrait mode
- [x] it uses `cacheConfig.force=true` if offline access doesn't make sense
