### PR TITLE
Docs: add info about application builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 * [Installation and Run](#installation-and-run)
+* [Building](#building)
 * [Environment](#environment)
 * [Testing](#testing)
 * [Project structure](#project-structure)
@@ -18,20 +19,41 @@
 
 > Note: we currently support only macOS.
 
-All necessary information are described in the official [React Native documentation](http://facebook.github.io/react-native/docs/getting-started.html#installing-dependencies). Basically you need to install Node and Watchman:
+All necessary information are described in the official [React Native documentation](http://facebook.github.io/react-native/docs/getting-started.html#installing-dependencies). Basically you need to install macOS dependencies:
 
 ```
-brew install node watchman
+brew install node watchman yarn
 gem install cocoapods
 ```
 
-Install Xcode and Android Studio. After that install all the necessary dependencies:
+Install Xcode and Android Studio. After that clone this repository and install all the necessary dependencies:
 
 ```
+git clone git@github.com:kiwicom/react-native-app.git
+cd react-native-app
 yarn install && ( cd ios ; pod install )
 ```
 
 And if you have Xcode already installed - just run `yarn ios`. It should open iPhone emulator with our application. Similarly for Android (`yarn android`) but you have to open Android emulator first.
+
+## Building
+
+**We currently do not have automated way of builds distribution.**
+
+Command `yarn ios` create build with `*.app` file in the `ios/build` folder. However, this command should be used only for development and for this reason the build itself does not contain bundled JS code. You must first start packager (`yarn start`) in order to use this build.
+
+The easier way how to build application with bundled JS code is using this command:
+
+```
+yarn ios --configuration=Release
+```
+
+This will do basically the same with few exceptions:
+
+1. build (`app/build/Build/Products/Release-*/*.app`) already contains bundled JS code therefore you don't need packager
+2. this build is in production mode and you cannot use dev menu or reload the app
+
+To test this build just drag and drop the `*.app` file to the simulator window.
 
 ## Environment
 

--- a/ios/reactNativeApp.xcodeproj/project.pbxproj
+++ b/ios/reactNativeApp.xcodeproj/project.pbxproj
@@ -251,20 +251,6 @@
 			remoteGlobalIDString = 2D2A28201D9B03D100D4039D;
 			remoteInfo = "RCTAnimation-tvOS";
 		};
-		63A98A42200602CE001DA42E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = EBF21BDC1FC498900052F4D5;
-			remoteInfo = jsinspector;
-		};
-		63A98A44200602CE001DA42E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = EBF21BFA1FC4989A0052F4D5;
-			remoteInfo = "jsinspector-tvOS";
-		};
 		63A98A46200602CE001DA42E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
@@ -550,8 +536,6 @@
 				3DAD3EAB1DF850E9000B6D8A /* libcxxreact.a */,
 				3DAD3EAD1DF850E9000B6D8A /* libjschelpers.a */,
 				3DAD3EAF1DF850E9000B6D8A /* libjschelpers.a */,
-				63A98A43200602CE001DA42E /* libjsinspector.a */,
-				63A98A45200602CE001DA42E /* libjsinspector-tvOS.a */,
 				63A98A47200602CE001DA42E /* libthird-party.a */,
 				63A98A49200602CE001DA42E /* libthird-party.a */,
 				63A98A4B200602CE001DA42E /* libdouble-conversion.a */,
@@ -1070,20 +1054,6 @@
 			remoteRef = 5E9157341DD0AC6500FF2AA8 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		63A98A43200602CE001DA42E /* libjsinspector.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libjsinspector.a;
-			remoteRef = 63A98A42200602CE001DA42E /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		63A98A45200602CE001DA42E /* libjsinspector-tvOS.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = "libjsinspector-tvOS.a";
-			remoteRef = 63A98A44200602CE001DA42E /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		63A98A47200602CE001DA42E /* libthird-party.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1514,6 +1484,7 @@
 					"-lc++",
 				);
 				PRODUCT_NAME = reactNativeApp;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -1536,6 +1507,7 @@
 					"-lc++",
 				);
 				PRODUCT_NAME = reactNativeApp;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;


### PR DESCRIPTION
Note: we currently do not support automated builds and build
distribution. This change just makes it possible to build and share iOS
builds in a fast way before we solve this automated path.

Closes #178

---
Please check this before merging (do not delete this checklist):

- [x] it works in landscape and portrait mode
- [x] it uses `cacheConfig.force=true` if offline access doesn't make sense
