### PR TITLE
ReduxContext: remove 'componentWillMount' method

### DIFF
--- a/app/redux/src/ReduxContext.js
+++ b/app/redux/src/ReduxContext.js
@@ -19,14 +19,15 @@ type Props = {|
  * you pass additional reducers to be registered.
  */
 export default class ReduxContext extends React.Component<Props> {
-  componentWillMount = () => {
-    // it's too late to register new reducers in componentDidMount
-    // they must be connected before rendering phase
+  constructor(props: Props) {
+    super(props);
+
+    // reducers must be connected before rendering phase
     Object.entries(this.props.reducers).map(([reducerName, reducerItself]) => {
       return (Store.asyncReducers[reducerName] = reducerItself);
     });
     Store.replaceReducer(createCombinedReducer(Store.asyncReducers));
-  };
+  }
 
   getChildContext() {
     return {


### PR DESCRIPTION
Methods 'componentWill*' are deprecated in next React version.
See: https://github.com/bvaughn/rfcs/blob/static-lifecycle-methods/text/0000-static-lifecycle-methods.md


---
Please check this before merging (do not delete this checklist):

- [ ] it works in landscape and portrait mode
- [ ] it uses `cacheConfig.force=true` if offline access doesn't make sense
