### PR TITLE
Shared: upgrade 'react-native-multi-slider' dependency

### DIFF
--- a/app/common/package.json
+++ b/app/common/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "main": "index.js",
   "dependencies": {
-    "@ptomasroos/react-native-multi-slider": "ptomasroos/react-native-multi-slider",
+    "@ptomasroos/react-native-multi-slider": "https://github.com/ptomasroos/react-native-multi-slider.git#2f83b6b8b700c0e6ace77c74b8af8a7d2ad83ba0",
     "react-native-image-progress": "^1.0.1",
     "react-native-modal": "^4.1.1",
     "react-native-svg": "5.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,9 +120,9 @@
   dependencies:
     cross-spawn "^5.1.0"
 
-"@ptomasroos/react-native-multi-slider@ptomasroos/react-native-multi-slider":
+"@ptomasroos/react-native-multi-slider@https://github.com/ptomasroos/react-native-multi-slider.git#2f83b6b8b700c0e6ace77c74b8af8a7d2ad83ba0":
   version "0.0.10"
-  resolved "https://codeload.github.com/ptomasroos/react-native-multi-slider/tar.gz/7398724080f8b49d121743cac89bc95304fc4483"
+  resolved "https://github.com/ptomasroos/react-native-multi-slider.git#2f83b6b8b700c0e6ace77c74b8af8a7d2ad83ba0"
 
 "@segment/loosely-validate-event@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
This change upgrades the dependency to the latest commit in the master
branch because they did not release the fixed version yet. We should
replace it later with something like '^0.0.12' (after the release).

See: https://github.com/ptomasroos/react-native-multi-slider/tree/2f83b6b8b700c0e6ace77c74b8af8a7d2ad83ba0

See: https://github.com/ptomasroos/react-native-multi-slider/pull/50


---
Please check this before merging (do not delete this checklist):

- [ ] it works in landscape and portrait mode
- [ ] it uses `cacheConfig.force=true` if offline access doesn't make sense
