### PR TITLE
Add margin to make photo stripe title visible on iphone x

### DIFF
--- a/app/hotels/src/gallery/PhotosStripe.js
+++ b/app/hotels/src/gallery/PhotosStripe.js
@@ -57,6 +57,7 @@ export default class PhotosStrip extends React.Component<Props> {
 const styles = StyleSheet.create({
   headerWrapper: {
     position: 'absolute',
+    marginTop: 10,
   },
   onCloseWrapper: {
     position: 'absolute',


### PR DESCRIPTION
---
Please check this before merging (do not delete this checklist):

- [ ] it works in landscape and portrait mode
- [ ] it uses `cacheConfig.force=true` if offline access doesn't make sense
