### PR TITLE
AdaptableLayout: fix memory leak

### DIFF
--- a/app/shared/src/Device.js
+++ b/app/shared/src/Device.js
@@ -19,7 +19,7 @@ function renewDimensions(): DimensionsType {
   return dimensions;
 }
 
-const events = [];
+const dimensionChangeListeners = [];
 
 /**
  * Node: there are no `getWidth` or `getHeight`. These dimensions are changing
@@ -34,12 +34,14 @@ export default {
    * @see: https://github.com/facebook/react-native/issues/16152
    */
   emitDimensionChanges(height: number, width: number) {
+    // store new dimensions to the memory so they persist
     dimensions = {
       height,
       width,
     };
 
-    events.forEach(event => {
+    // invoke listeners with new dimensions
+    dimensionChangeListeners.forEach(event => {
       event({ height, width });
     });
   },
@@ -48,8 +50,15 @@ export default {
    * Dimensions may change (landscape <-> portrait, multitasking). Subscribe to
    * this event if you want to be notified about these changes.
    */
-  subscribeToDimensionChanges(handler: (dimensions: DimensionsType) => void) {
-    events.push(handler);
+  subscribeToDimensionChanges(
+    handler: (dimensions: DimensionsType) => void,
+  ): () => void {
+    dimensionChangeListeners.push(handler);
+
+    return function unsubscribe() {
+      const index = dimensionChangeListeners.indexOf(handler);
+      dimensionChangeListeners.splice(index, 1);
+    };
   },
 
   /**

--- a/app/shared/src/__tests__/Device.test.js
+++ b/app/shared/src/__tests__/Device.test.js
@@ -1,0 +1,54 @@
+// @flow
+
+import Device from '../Device';
+
+it('is able to emit dimension changes', () => {
+  const sink = [];
+  Device.subscribeToDimensionChanges(newDimensions => {
+    sink.push(newDimensions);
+  });
+
+  expect(sink).toEqual([]);
+  Device.emitDimensionChanges(1, 2);
+  expect(sink).toEqual([
+    {
+      height: 1,
+      width: 2,
+    },
+  ]);
+  Device.emitDimensionChanges(3, 4);
+  expect(sink).toEqual([
+    {
+      height: 1,
+      width: 2,
+    },
+    {
+      height: 3,
+      width: 4,
+    },
+  ]);
+});
+
+it('is possible to unsubscribe', () => {
+  const sink = [];
+  const unsubscribe = Device.subscribeToDimensionChanges(newDimensions => {
+    sink.push(newDimensions);
+  });
+
+  expect(sink).toEqual([]);
+  Device.emitDimensionChanges(1, 2);
+  expect(sink).toEqual([
+    {
+      height: 1,
+      width: 2,
+    },
+  ]);
+  unsubscribe();
+  Device.emitDimensionChanges(3, 4);
+  expect(sink).toEqual([
+    {
+      height: 1,
+      width: 2,
+    },
+  ]);
+});

--- a/app/shared/src/view/AdaptableLayout.js
+++ b/app/shared/src/view/AdaptableLayout.js
@@ -14,16 +14,24 @@ type State = {|
 |};
 
 export default class AdaptableLayout extends React.Component<Props, State> {
+  unsubscribeDimensionListener: Function = () => {};
+
   state = {
     wideLayout: Device.isWideLayout(),
   };
 
   componentDidMount = () => {
-    Device.subscribeToDimensionChanges(({ width }) => {
-      this.setState({
-        wideLayout: width > Device.getWideDeviceThreshold(),
-      });
-    });
+    this.unsubscribeDimensionListener = Device.subscribeToDimensionChanges(
+      ({ width }) => {
+        this.setState({
+          wideLayout: width > Device.getWideDeviceThreshold(),
+        });
+      },
+    );
+  };
+
+  componentWillUnmount = () => {
+    this.unsubscribeDimensionListener();
   };
 
   render = () => {


### PR DESCRIPTION
Function `Device.subscribeToDimensionChanges` now returns unsubscribe
function (Redux pattern) so it's easy to unsubscribe during component
unmount. This way the `setState` won't be called on unmounted component.