### PR TITLE
TouchableItem: use exact props

### DIFF
--- a/app/accessibility/index.js
+++ b/app/accessibility/index.js
@@ -1,0 +1,39 @@
+// @flow
+
+type AccessibilityTraitsValues =
+  | 'none'
+  | 'button'
+  | 'link'
+  | 'header'
+  | 'search'
+  | 'image'
+  | 'selected'
+  | 'plays'
+  | 'key'
+  | 'text'
+  | 'summary'
+  | 'disabled'
+  | 'frequentUpdates'
+  | 'startsMedia'
+  | 'adjustable'
+  | 'allowsDirectInteraction'
+  | 'pageTurn';
+
+// See: https://facebook.github.io/react-native/docs/accessibility.html
+export type AccessibilityProps = {|
+  accessible?: boolean,
+  accessibilityLabel?: string,
+  accessibilityTraits?:  // iOS only
+    | AccessibilityTraitsValues
+    | $ReadOnlyArray<AccessibilityTraitsValues>,
+  accessibilityViewIsModal?: boolean, //iOS only
+  onAccessibilityTap?: Function, // iOS only
+  onMagicTap?: Function, // iOS only
+  accessibilityComponentType?:  // Android only
+    | 'none'
+    | 'button'
+    | 'radiobutton_checked'
+    | 'radiobutton_unchecked',
+  accessibilityLiveRegion?: 'none' | 'polite' | 'assertive', // Android only
+  importantForAccessibility?: 'auto' | 'yes' | 'no' | 'no-hide-descendants', // Android only
+|};

--- a/app/accessibility/package.json
+++ b/app/accessibility/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@kiwicom/react-native-app-accessibility",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/app/hotels/src/allHotels/searchForm/guests/Guests.js
+++ b/app/hotels/src/allHotels/searchForm/guests/Guests.js
@@ -60,7 +60,7 @@ export default class Guests extends React.Component<Props, State> {
 
     return (
       <View>
-        <TouchableItem onPress={this.handlePopupToggle} activeOpacity={0.6}>
+        <TouchableItem onPress={this.handlePopupToggle}>
           <View style={buttonStyles.buttonWrapper}>
             <Icon
               name="people"

--- a/app/hotels/src/allHotels/searchForm/guests/__tests__/__snapshots__/Guests.test.js.snap
+++ b/app/hotels/src/allHotels/searchForm/guests/__tests__/__snapshots__/Guests.test.js.snap
@@ -3,7 +3,6 @@
 exports[`Guests Render all inputs 1`] = `
 <View>
   <TouchableItem
-    activeOpacity={0.6}
     borderlessRipple={false}
     onPress={[Function]}
     rippleColor="rgba(0, 0, 0, .32)"

--- a/app/hotels/src/singleHotel/bookNow/BookNow.js
+++ b/app/hotels/src/singleHotel/bookNow/BookNow.js
@@ -72,7 +72,7 @@ export class BookNow extends React.Component<Props> {
     return (
       price && (
         <View style={styles.buttonWrapper}>
-          <TouchableItem onPress={this.handleGoToPayment} activeOpacity={0.6}>
+          <TouchableItem onPress={this.handleGoToPayment}>
             <BookNowText
               price={
                 <Price

--- a/app/hotels/src/singleHotel/bookNow/__tests__/__snapshots__/BookNow.test.js.snap
+++ b/app/hotels/src/singleHotel/bookNow/__tests__/__snapshots__/BookNow.test.js.snap
@@ -14,7 +14,6 @@ exports[`renders without crashing 1`] = `
   }
 >
   <TouchableItem
-    activeOpacity={0.6}
     borderlessRipple={false}
     onPress={[Function]}
     rippleColor="rgba(0, 0, 0, .32)"

--- a/app/shared/package.json
+++ b/app/shared/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "main": "index.js",
   "dependencies": {
+    "@kiwicom/react-native-app-accessibility": "^0",
     "@kiwicom/react-native-native-modules": "^0.1.21",
     "@ptomasroos/react-native-multi-slider": "^0.0.12",
     "react-native-datepicker": "^1.6.0",

--- a/app/shared/src/TouchableItem.js
+++ b/app/shared/src/TouchableItem.js
@@ -7,19 +7,21 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import type { AccessibilityProps } from '@kiwicom/react-native-app-accessibility';
 
 import { type StylePropType } from '../types/Styles';
 
-// Props are not exact: all additional props allowed for TouchableOpacity and
-// TouchableNativeFeedback
-type Props = {
+type Props = {|
   children: React.Node,
+  onPress: () => void,
   style?: StylePropType,
-
+  onLongPress?: () => void,
+  delayPressIn?: number,
   // Should the ripple render outside of the view bounds?
   borderlessRipple?: boolean,
   rippleColor?: string,
-};
+  ...AccessibilityProps,
+|};
 
 /**
  * TouchableItem renders a touchable that looks native on both iOS and Android.
@@ -71,6 +73,10 @@ export default class TouchableItem extends React.Component<Props> {
       );
     }
 
-    return <TouchableOpacity {...this.props}>{children}</TouchableOpacity>;
+    return (
+      <TouchableOpacity activeOpacity={0.5} {...this.props}>
+        {children}
+      </TouchableOpacity>
+    );
   };
 }

--- a/app/shared/src/__tests__/TouchableItem.ripple.test.js
+++ b/app/shared/src/__tests__/TouchableItem.ripple.test.js
@@ -18,12 +18,13 @@ jest.mock('Platform', () => ({
 }));
 
 const renderer = new ShallowRenderer();
+const VoidAction = () => {};
 
 describe('TouchableItem with ripple effect', () => {
   it('renders with foreground', () => {
     expect(
       renderer.render(
-        <TouchableItem>
+        <TouchableItem onPress={VoidAction}>
           <Text>line</Text>
         </TouchableItem>,
       ),
@@ -33,7 +34,7 @@ describe('TouchableItem with ripple effect', () => {
   it('renders with ripple color', () => {
     expect(
       renderer.render(
-        <TouchableItem rippleColor="red">
+        <TouchableItem rippleColor="red" onPress={VoidAction}>
           <Text>line</Text>
         </TouchableItem>,
       ),
@@ -43,7 +44,7 @@ describe('TouchableItem with ripple effect', () => {
   it('disables foreground in borderless mode', () => {
     expect(
       renderer.render(
-        <TouchableItem borderlessRipple={true}>
+        <TouchableItem borderlessRipple={true} onPress={VoidAction}>
           <Text>line</Text>
         </TouchableItem>,
       ),

--- a/app/shared/src/__tests__/TouchableItem.test.js
+++ b/app/shared/src/__tests__/TouchableItem.test.js
@@ -8,13 +8,14 @@ import Text from '../Text';
 import TouchableItem from '../TouchableItem';
 
 const renderer = new ShallowRenderer();
+const VoidAction = () => {};
 
 describe('TouchableItem with children', () => {
   it('throws error for multiple children', () => {
     // this is fine - only one child
     expect(
       renderer.render(
-        <TouchableItem>
+        <TouchableItem onPress={VoidAction}>
           <Text>this is OK</Text>
         </TouchableItem>,
       ),
@@ -23,7 +24,7 @@ describe('TouchableItem with children', () => {
     // this is fine - only one child
     expect(
       renderer.render(
-        <TouchableItem>
+        <TouchableItem onPress={VoidAction}>
           <View>
             <Text>line 1</Text>
             <Text>line 2</Text>
@@ -35,7 +36,7 @@ describe('TouchableItem with children', () => {
     // this is not fine - two children
     expect(() =>
       renderer.render(
-        <TouchableItem>
+        <TouchableItem onPress={VoidAction}>
           <Text>line 1</Text>
           <Text>line 2</Text>
         </TouchableItem>,

--- a/app/shared/src/__tests__/__snapshots__/TouchableItem.ripple.test.js.snap
+++ b/app/shared/src/__tests__/__snapshots__/TouchableItem.ripple.test.js.snap
@@ -4,6 +4,7 @@ exports[`TouchableItem with ripple effect disables foreground in borderless mode
 <DummyTouchableNativeFeedback
   background={undefined}
   borderlessRipple={true}
+  onPress={[Function]}
   rippleColor="rgba(0, 0, 0, .32)"
   style={null}
   useForeground={false}
@@ -22,6 +23,7 @@ exports[`TouchableItem with ripple effect renders with foreground 1`] = `
 <DummyTouchableNativeFeedback
   background={undefined}
   borderlessRipple={false}
+  onPress={[Function]}
   rippleColor="rgba(0, 0, 0, .32)"
   style={null}
   useForeground={true}
@@ -40,6 +42,7 @@ exports[`TouchableItem with ripple effect renders with ripple color 1`] = `
 <DummyTouchableNativeFeedback
   background={undefined}
   borderlessRipple={false}
+  onPress={[Function]}
   rippleColor="red"
   style={null}
   useForeground={true}

--- a/app/shared/src/__tests__/__snapshots__/TouchableItem.test.js.snap
+++ b/app/shared/src/__tests__/__snapshots__/TouchableItem.test.js.snap
@@ -2,8 +2,9 @@
 
 exports[`TouchableItem with children throws error for multiple children 1`] = `
 <TouchableOpacity
-  activeOpacity={0.2}
+  activeOpacity={0.5}
   borderlessRipple={false}
+  onPress={[Function]}
   rippleColor="rgba(0, 0, 0, .32)"
 >
   <Text>
@@ -14,8 +15,9 @@ exports[`TouchableItem with children throws error for multiple children 1`] = `
 
 exports[`TouchableItem with children throws error for multiple children 2`] = `
 <TouchableOpacity
-  activeOpacity={0.2}
+  activeOpacity={0.5}
   borderlessRipple={false}
+  onPress={[Function]}
   rippleColor="rgba(0, 0, 0, .32)"
 >
   <View>

--- a/app/shared/src/buttons/Button.js
+++ b/app/shared/src/buttons/Button.js
@@ -42,11 +42,7 @@ export default function Button(props: Props) {
   );
 
   if (props.onPress) {
-    return (
-      <TouchableItem onPress={props.onPress} activeOpacity={0.6}>
-        {buttonView}
-      </TouchableItem>
-    );
+    return <TouchableItem onPress={props.onPress}>{buttonView}</TouchableItem>;
   } else {
     return buttonView;
   }

--- a/app/shared/src/buttons/IncrementDecrementButtons.js
+++ b/app/shared/src/buttons/IncrementDecrementButtons.js
@@ -33,11 +33,7 @@ const Button = ({
   );
 
   if (touchable) {
-    return (
-      <TouchableItem activeOpacity={0.6} onPress={onPress}>
-        {inner}
-      </TouchableItem>
-    );
+    return <TouchableItem onPress={onPress}>{inner}</TouchableItem>;
   }
 
   return inner;

--- a/app/shared/src/buttons/__tests__/__snapshots__/Button.test.js.snap
+++ b/app/shared/src/buttons/__tests__/__snapshots__/Button.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`renders button with custom title 1`] = `
 <TouchableItem
-  activeOpacity={0.6}
   borderlessRipple={false}
   onPress={[Function]}
   rippleColor="rgba(0, 0, 0, .32)"

--- a/app/shared/src/navigation/HeaderRightButton.js
+++ b/app/shared/src/navigation/HeaderRightButton.js
@@ -8,8 +8,7 @@ import TouchableItem from '../TouchableItem';
 import Icon from '../icons/Icon';
 
 type Props = {|
-  onPress?: () => void,
-  pressColorAndroid?: string,
+  onPress: () => void,
   tintColor?: string,
   onLongPress?: (React.ElementRef<typeof TouchableItem>) => void,
 |};
@@ -27,7 +26,6 @@ export default class HeaderRightButton extends React.PureComponent<
   };
 
   static defaultProps = {
-    pressColorAndroid: 'rgba(0, 0, 0, .32)',
     tintColor: '#fff',
   };
 
@@ -44,7 +42,7 @@ export default class HeaderRightButton extends React.PureComponent<
   };
 
   render = () => {
-    const { onPress, pressColorAndroid, tintColor } = this.props;
+    const { onPress, tintColor } = this.props;
 
     return (
       <TouchableItem
@@ -52,7 +50,6 @@ export default class HeaderRightButton extends React.PureComponent<
         accessibilityTraits="button"
         delayPressIn={0}
         onPress={onPress}
-        pressColor={pressColorAndroid}
         style={styles.container}
         borderlessRipple={true}
         onLongPress={this.onLongPress}


### PR DESCRIPTION
I believe that being more restrictive and use exact props is much
better. This also adds default `activeOpacity={0.5}` to every element by
 default so it's not necessary to set it manually (this is why I
 actually started this change).