### PR TITLE
HotelTitle: remove line heights to allow free text expansion

### DIFF
--- a/app/hotels/src/allHotels/HotelTitle.js
+++ b/app/hotels/src/allHotels/HotelTitle.js
@@ -25,24 +25,14 @@ const style = StyleSheet.create({
     color: Color.textDark,
     android: {
       fontSize: 15,
-      lineHeight: 18,
     },
     ios: {
       fontSize: 14,
-      lineHeight: 16,
     },
   },
   rating: {
     color: Color.grey.$600,
     fontSize: 9,
-    lineHeight: 9,
-    alignSelf: 'flex-end',
-    android: {
-      paddingBottom: 3,
-    },
-    ios: {
-      paddingBottom: 1,
-    },
   },
   distance: {
     marginVertical: 6,
@@ -82,6 +72,7 @@ function HotelTitle({ data }: Props) {
           <Stars rating={hotelStars} />
         </Text>
       </Text>
+
       <View style={style.distance}>
         <Distance hotel={data && data.hotel} />
       </View>

--- a/app/shared/src/Color.js
+++ b/app/shared/src/Color.js
@@ -86,9 +86,10 @@ const {
   textLight,
 } = NativeModules.RNColors;
 
+/**
+ * @see https://images.kiwi.com/content-media/kiwicom_brand_colours.pdf
+ */
 export default {
-  // brand colors
-  // https://images.kiwi.com/content-media/kiwicom_brand_colours.pdf
   brand,
   brandSecondary,
   buttercup,
@@ -97,5 +98,6 @@ export default {
   textDark,
   textMedium,
   textLight,
+
   ...ColorPalette,
 };


### PR DESCRIPTION
Line height doesn't work very well for nested text strings. So I removed
 them completely in order to improve the title design on Android. We
 should I general be very careful with line heights especially on
 Android devices.

Replaces: https://github.com/kiwicom/react-native-app/pull/400

@tbergq Please check it if everything is still alright (I don't care about line heights in Zeplin).