### PR TITLE
Text: improve styles inheritance to be RN compatible

### DIFF
--- a/app/hotels/src/singleHotel/header/__tests__/__snapshots__/Rating.test.js.snap
+++ b/app/hotels/src/singleHotel/header/__tests__/__snapshots__/Rating.test.js.snap
@@ -8,13 +8,13 @@ Array [
     ellipsizeMode="tail"
     style={
       Array [
-        undefined,
         Object {
           "color": "#30363d",
           "fontSize": 14,
           "fontWeight": "normal",
           "letterSpacing": -0.15,
         },
+        undefined,
       ]
     }
   >
@@ -26,13 +26,13 @@ Array [
     ellipsizeMode="tail"
     style={
       Array [
-        undefined,
         Object {
           "color": "#30363d",
           "fontSize": 14,
           "fontWeight": "normal",
           "letterSpacing": -0.15,
         },
+        undefined,
       ]
     }
   >
@@ -44,13 +44,13 @@ Array [
     ellipsizeMode="tail"
     style={
       Array [
-        undefined,
         Object {
           "color": "#30363d",
           "fontSize": 14,
           "fontWeight": "normal",
           "letterSpacing": -0.15,
         },
+        undefined,
       ]
     }
   >
@@ -67,13 +67,13 @@ Array [
     ellipsizeMode="tail"
     style={
       Array [
-        undefined,
         Object {
           "color": "#30363d",
           "fontSize": 14,
           "fontWeight": "normal",
           "letterSpacing": -0.15,
         },
+        undefined,
       ]
     }
   >
@@ -85,13 +85,13 @@ Array [
     ellipsizeMode="tail"
     style={
       Array [
-        undefined,
         Object {
           "color": "#30363d",
           "fontSize": 14,
           "fontWeight": "normal",
           "letterSpacing": -0.15,
         },
+        undefined,
       ]
     }
   >
@@ -103,13 +103,13 @@ Array [
     ellipsizeMode="tail"
     style={
       Array [
-        undefined,
         Object {
           "color": "#30363d",
           "fontSize": 14,
           "fontWeight": "normal",
           "letterSpacing": -0.15,
         },
+        undefined,
       ]
     }
   >
@@ -126,13 +126,13 @@ Array [
     ellipsizeMode="tail"
     style={
       Array [
-        undefined,
         Object {
           "color": "#30363d",
           "fontSize": 14,
           "fontWeight": "normal",
           "letterSpacing": -0.15,
         },
+        undefined,
       ]
     }
   >
@@ -144,13 +144,13 @@ Array [
     ellipsizeMode="tail"
     style={
       Array [
-        undefined,
         Object {
           "color": "#30363d",
           "fontSize": 14,
           "fontWeight": "normal",
           "letterSpacing": -0.15,
         },
+        undefined,
       ]
     }
   >
@@ -162,13 +162,13 @@ Array [
     ellipsizeMode="tail"
     style={
       Array [
-        undefined,
         Object {
           "color": "#30363d",
           "fontSize": 14,
           "fontWeight": "normal",
           "letterSpacing": -0.15,
         },
+        undefined,
       ]
     }
   >

--- a/app/playground/Playground.js
+++ b/app/playground/Playground.js
@@ -8,7 +8,7 @@ import { DummyTranslation } from '@kiwicom/react-native-app-translations';
 import PlaygroundRenderer from './PlaygroundRenderer';
 // Import component tests you want to show in the Playground here:
 // eslint-disable-next-line
-import _ from '../shared/src/forms/__tests__/Slider.test.js';
+import _ from '../shared/src/__tests__/Text.test';
 
 const PlaygroundSection = props => (
   <View style={styles.section}>

--- a/app/shared/src/__tests__/Text.test.js
+++ b/app/shared/src/__tests__/Text.test.js
@@ -62,7 +62,7 @@ it('supports multiple nested strings', () => {
   );
 });
 
-it('works applies the styles recursively', () => {
+it('applies the styles recursively', () => {
   const Fence = ({ children }: {| children: React.Node |}) => children;
   PlaygroundRenderer.render(
     <Text style={{ fontWeight: 'bold' }}>

--- a/app/shared/src/__tests__/__snapshots__/Text.test.js.snap
+++ b/app/shared/src/__tests__/__snapshots__/Text.test.js.snap
@@ -1,18 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders with additional style properties 1`] = `
+exports[`applies the styles recursively 1`] = `
 <Text
   accessible={true}
   allowFontScaling={true}
   ellipsizeMode="tail"
   style={
     Array [
-      undefined,
       Object {
         "color": "#30363d",
         "fontSize": 14,
-        "fontWeight": "bold",
+        "fontWeight": "normal",
         "letterSpacing": -0.15,
+      },
+      Object {
+        "fontWeight": "bold",
       },
     ]
   }
@@ -22,16 +24,47 @@ exports[`renders with additional style properties 1`] = `
     allowFontScaling={true}
     ellipsizeMode="tail"
     style={
-      Array [
-        Object {
-          "color": "#30363d",
-          "fontSize": 14,
-          "fontWeight": "bold",
-          "letterSpacing": -0.15,
-        },
-        undefined,
-      ]
+      Object {
+        "color": "red",
+      }
     }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={undefined}
+    >
+      bold and red text
+    </Text>
+  </Text>
+</Text>
+`;
+
+exports[`renders with additional style properties 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Array [
+      Object {
+        "color": "#30363d",
+        "fontSize": 14,
+        "fontWeight": "normal",
+        "letterSpacing": -0.15,
+      },
+      Object {
+        "fontWeight": "bold",
+      },
+    ]
+  }
+>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={undefined}
   >
     bold text
   </Text>
@@ -45,13 +78,13 @@ exports[`renders with the default properties for iOS 1`] = `
   ellipsizeMode="tail"
   style={
     Array [
-      undefined,
       Object {
         "color": "#30363d",
         "fontSize": 14,
         "fontWeight": "normal",
         "letterSpacing": -0.15,
       },
+      undefined,
     ]
   }
 >
@@ -59,17 +92,7 @@ exports[`renders with the default properties for iOS 1`] = `
     accessible={true}
     allowFontScaling={true}
     ellipsizeMode="tail"
-    style={
-      Array [
-        Object {
-          "color": "#30363d",
-          "fontSize": 14,
-          "fontWeight": "normal",
-          "letterSpacing": -0.15,
-        },
-        undefined,
-      ]
-    }
+    style={undefined}
   >
     normal text
   </Text>
@@ -83,12 +106,14 @@ exports[`supports multiple nested strings 1`] = `
   ellipsizeMode="tail"
   style={
     Array [
-      undefined,
       Object {
-        "color": "red",
+        "color": "#30363d",
         "fontSize": 14,
         "fontWeight": "normal",
         "letterSpacing": -0.15,
+      },
+      Object {
+        "color": "red",
       },
     ]
   }
@@ -97,28 +122,13 @@ exports[`supports multiple nested strings 1`] = `
     accessible={true}
     allowFontScaling={true}
     ellipsizeMode="tail"
-    style={
-      Array [
-        Object {
-          "color": "red",
-          "fontSize": 14,
-          "fontWeight": "normal",
-          "letterSpacing": -0.15,
-        },
-        undefined,
-      ]
-    }
+    style={undefined}
   >
     <Text
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={
-        Array [
-          undefined,
-          undefined,
-        ]
-      }
+      style={undefined}
     >
       red normal text 
     </Text>
@@ -127,28 +137,13 @@ exports[`supports multiple nested strings 1`] = `
     accessible={true}
     allowFontScaling={true}
     ellipsizeMode="tail"
-    style={
-      Array [
-        Object {
-          "color": "red",
-          "fontSize": 14,
-          "fontWeight": "normal",
-          "letterSpacing": -0.15,
-        },
-        undefined,
-      ]
-    }
+    style={undefined}
   >
     <Text
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={
-        Array [
-          undefined,
-          undefined,
-        ]
-      }
+      style={undefined}
     >
       and red normal text
     </Text>
@@ -163,12 +158,14 @@ exports[`supports nested styles 1`] = `
   ellipsizeMode="tail"
   style={
     Array [
-      undefined,
       Object {
         "color": "#30363d",
         "fontSize": 14,
-        "fontWeight": "bold",
+        "fontWeight": "normal",
         "letterSpacing": -0.15,
+      },
+      Object {
+        "fontWeight": "bold",
       },
     ]
   }
@@ -177,17 +174,7 @@ exports[`supports nested styles 1`] = `
     accessible={true}
     allowFontScaling={true}
     ellipsizeMode="tail"
-    style={
-      Array [
-        Object {
-          "color": "#30363d",
-          "fontSize": 14,
-          "fontWeight": "bold",
-          "letterSpacing": -0.15,
-        },
-        undefined,
-      ]
-    }
+    style={undefined}
   >
     bold text 
   </Text>
@@ -196,87 +183,18 @@ exports[`supports nested styles 1`] = `
     allowFontScaling={true}
     ellipsizeMode="tail"
     style={
-      Array [
-        Object {
-          "color": "#30363d",
-          "fontSize": 14,
-          "fontWeight": "bold",
-          "letterSpacing": -0.15,
-        },
-        Object {
-          "color": "red",
-        },
-      ]
+      Object {
+        "color": "red",
+      }
     }
   >
     <Text
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={
-        Array [
-          Object {
-            "color": "red",
-          },
-          undefined,
-        ]
-      }
+      style={undefined}
     >
       and bold-red text
-    </Text>
-  </Text>
-</Text>
-`;
-
-exports[`works applies the styles recursively 1`] = `
-<Text
-  accessible={true}
-  allowFontScaling={true}
-  ellipsizeMode="tail"
-  style={
-    Array [
-      undefined,
-      Object {
-        "color": "#30363d",
-        "fontSize": 14,
-        "fontWeight": "bold",
-        "letterSpacing": -0.15,
-      },
-    ]
-  }
->
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    ellipsizeMode="tail"
-    style={
-      Array [
-        Object {
-          "color": "#30363d",
-          "fontSize": 14,
-          "fontWeight": "bold",
-          "letterSpacing": -0.15,
-        },
-        Object {
-          "color": "red",
-        },
-      ]
-    }
-  >
-    <Text
-      accessible={true}
-      allowFontScaling={true}
-      ellipsizeMode="tail"
-      style={
-        Array [
-          Object {
-            "color": "red",
-          },
-          undefined,
-        ]
-      }
-    >
-      bold and red text
     </Text>
   </Text>
 </Text>
@@ -289,12 +207,14 @@ exports[`works even with the distant Text nodes 1`] = `
   ellipsizeMode="tail"
   style={
     Array [
-      undefined,
       Object {
         "color": "#30363d",
         "fontSize": 14,
-        "fontWeight": "bold",
+        "fontWeight": "normal",
         "letterSpacing": -0.15,
+      },
+      Object {
+        "fontWeight": "bold",
       },
     ]
   }
@@ -303,28 +223,13 @@ exports[`works even with the distant Text nodes 1`] = `
     accessible={true}
     allowFontScaling={true}
     ellipsizeMode="tail"
-    style={
-      Array [
-        Object {
-          "color": "#30363d",
-          "fontSize": 14,
-          "fontWeight": "bold",
-          "letterSpacing": -0.15,
-        },
-        undefined,
-      ]
-    }
+    style={undefined}
   >
     <Text
       accessible={true}
       allowFontScaling={true}
       ellipsizeMode="tail"
-      style={
-        Array [
-          undefined,
-          undefined,
-        ]
-      }
+      style={undefined}
     >
       bold default text
     </Text>

--- a/app/shared/src/errors/__tests__/__snapshots__/GeneralError.test.js.snap
+++ b/app/shared/src/errors/__tests__/__snapshots__/GeneralError.test.js.snap
@@ -17,12 +17,14 @@ exports[`renders as expected 1`] = `
       ellipsizeMode="tail"
       style={
         Array [
-          undefined,
           Object {
-            "color": "#f44336",
+            "color": "#30363d",
             "fontSize": 14,
             "fontWeight": "normal",
             "letterSpacing": -0.15,
+          },
+          Object {
+            "color": "#f44336",
             "textAlign": "center",
           },
         ]
@@ -32,18 +34,7 @@ exports[`renders as expected 1`] = `
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        style={
-          Array [
-            Object {
-              "color": "#f44336",
-              "fontSize": 14,
-              "fontWeight": "normal",
-              "letterSpacing": -0.15,
-              "textAlign": "center",
-            },
-            undefined,
-          ]
-        }
+        style={undefined}
       >
         Error Message
       </Text>

--- a/app/shared/src/errors/__tests__/__snapshots__/PartialFailure.test.js.snap
+++ b/app/shared/src/errors/__tests__/__snapshots__/PartialFailure.test.js.snap
@@ -8,13 +8,13 @@ Array [
     ellipsizeMode="tail"
     style={
       Array [
-        undefined,
         Object {
           "color": "#30363d",
           "fontSize": 14,
           "fontWeight": "normal",
           "letterSpacing": -0.15,
         },
+        undefined,
       ]
     }
   >
@@ -51,13 +51,13 @@ Array [
         ellipsizeMode="tail"
         style={
           Array [
-            undefined,
             Object {
               "color": "#30363d",
               "fontSize": 14,
               "fontWeight": "normal",
               "letterSpacing": -0.15,
             },
+            undefined,
           ]
         }
       >


### PR DESCRIPTION
Now I probably finally understand how does it work. Our default style
must be applied on the root (top) Text component only and inner deeply
nested components are inheriting previous styles only if their style is
undefined... :)

@tbergq Please also try your use-case. I rethought the internal implementation completely so now it behaves the same as RN implementation and it should just work. (I also don't know how to unit test this style changes on state change)