### PR TITLE
Eslint: add 'react-native' rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 const OFF = 0;
+const WARNING = 1;
 const ERROR = 2;
 
 module.exports = {
@@ -17,7 +18,13 @@ module.exports = {
       jsx: true,
     },
   },
-  plugins: ['import', 'prettier', 'react', 'flowtype'],
+  plugins: [
+    'import',
+    'prettier',
+    'react',
+    'react-native',
+    'flowtype',
+  ],
   extends: [
     'eslint:recommended',
     'plugin:react/recommended',
@@ -74,6 +81,8 @@ module.exports = {
     'react/jsx-no-bind': ERROR,
     'react/no-access-state-in-setstate': ERROR,
     'react/prop-types': OFF, // we use Flow instead,
+    'react-native/no-unused-styles': ERROR,
+    'react-native/no-inline-styles': WARNING,
     'flowtype/require-valid-file-annotation': [ERROR, 'always'],
   },
 };

--- a/app/hotels/src/allHotels/searchForm/locationPicker/LocationPickerScreen.js
+++ b/app/hotels/src/allHotels/searchForm/locationPicker/LocationPickerScreen.js
@@ -54,13 +54,6 @@ const styles = StyleSheet.create({
       fontWeight: '600',
     },
   },
-  confirmButton: {
-    padding: 8,
-    paddingRight: 10,
-  },
-  disabled: {
-    opacity: 0.4,
-  },
   container: {
     flex: 1,
   },

--- a/app/hotels/src/singleHotel/hotelInformation/location/Location.js
+++ b/app/hotels/src/singleHotel/hotelInformation/location/Location.js
@@ -37,7 +37,6 @@ const styles = StyleSheet.create({
   rightColumn: {
     flex: 1,
   },
-  mapOverlay: StyleSheet.absoluteFillObject,
   addressLine: {
     fontSize: 14,
     lineHeight: 19,

--- a/app/shared/src/forms/DatePicker.js
+++ b/app/shared/src/forms/DatePicker.js
@@ -10,6 +10,7 @@ import Color from '../Color';
 
 const customStyles = StyleSheet.create({
   // date input wrapper (View)
+  // eslint-disable-next-line react-native/no-unused-styles
   dateInput: {
     borderWidth: 0,
     padding: 10,
@@ -18,6 +19,7 @@ const customStyles = StyleSheet.create({
     alignItems: 'flex-start',
   },
   // text inside of the date input wrapper (Text)
+  // eslint-disable-next-line react-native/no-unused-styles
   dateText: {
     color: Color.textDark,
     android: {
@@ -33,6 +35,7 @@ const customStyles = StyleSheet.create({
     marginLeft: 10,
   },
   // touchable area around the 'dateInput' (View)
+  // eslint-disable-next-line react-native/no-unused-styles
   dateTouchBody: {
     backgroundColor: '#fff',
     android: {
@@ -45,10 +48,12 @@ const customStyles = StyleSheet.create({
     },
   },
   // Confirm button text styling
+  // eslint-disable-next-line react-native/no-unused-styles
   btnTextConfirm: {
     color: Color.brand,
   },
   // Cancel button text styling
+  // eslint-disable-next-line react-native/no-unused-styles
   btnTextCancel: {
     color: Color.brand,
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-prettier": "^2.3.1",
     "eslint-plugin-react": "^7.4.0",
+    "eslint-plugin-react-native": "^3.2.1",
     "flow-bin": "^0.67.0",
     "jest": "22.4.3",
     "metro-bundler": "^0.22.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1983,6 +1983,16 @@ eslint-plugin-prettier@^2.3.1:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
+eslint-plugin-react-native-globals@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native-globals/-/eslint-plugin-react-native-globals-0.1.2.tgz#ee1348bc2ceb912303ce6bdbd22e2f045ea86ea2"
+
+eslint-plugin-react-native@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-3.2.1.tgz#04fcadd3285b7cd2f27146e640c941b00acc4e7e"
+  dependencies:
+    eslint-plugin-react-native-globals "^0.1.1"
+
 eslint-plugin-react@^7.4.0:
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz#f606c719dbd8a1a2b3d25c16299813878cca0160"


### PR DESCRIPTION
Rule 'no-inline-styles' now throws warnings into console and we should
continuously fixing it (and change this rule to throw the errors).

See: https://github.com/Intellicode/eslint-plugin-react-native