### PR TITLE
Translations: fix transformation prop propagation

### DIFF
--- a/app/translations/src/DummyTranslation.js
+++ b/app/translations/src/DummyTranslation.js
@@ -3,8 +3,13 @@
 import * as React from 'react';
 import { Text } from '@kiwicom/react-native-app-shared';
 
+import CaseTransform, {
+  type SupportedTransformationsType,
+} from './transformations/CaseTransform';
+
 type Props = {|
   id: ?string | ?number,
+  textTransform?: SupportedTransformationsType,
 |};
 
 /**
@@ -30,7 +35,7 @@ export default class DummyTranslation extends React.Component<Props> {
         $FlowExpectedError: we do not allow to use 'string' in the 'Text'
         components but translations are exceptions.
       */}
-      {this.props.id}
+      {CaseTransform(this.props.id, this.props.textTransform)}
     </Text>
   );
 }

--- a/app/translations/src/Translation.js
+++ b/app/translations/src/Translation.js
@@ -5,8 +5,9 @@ import { NativeModules } from 'react-native';
 import { Text } from '@kiwicom/react-native-app-shared';
 
 import DefaultVocabulary, { type TranslationKeys } from './DefaultVocabulary';
-
-type SupportedTransformationsType = 'lowercase' | 'uppercase';
+import CaseTransform, {
+  type SupportedTransformationsType,
+} from './transformations/CaseTransform';
 
 type Props = {|
   id: TranslationKeys,
@@ -17,20 +18,6 @@ type Props = {|
 export default class Translation extends React.Component<Props> {
   // use this property to highlight translations for screenshoting or debugging
   highlightTranslations = false;
-
-  transformText = (
-    text: string,
-    transformation?: SupportedTransformationsType,
-  ): string => {
-    switch (transformation) {
-      case 'uppercase':
-        return text.toUpperCase();
-      case 'lowercase':
-        return text.toLowerCase();
-      default:
-        return text;
-    }
-  };
 
   replaceValues = (text: string, values?: Object): string => {
     const VARIABLE_REGEX = /__([0-9]+_)?([a-zA-Z-_]+)__/g;
@@ -74,7 +61,7 @@ export default class Translation extends React.Component<Props> {
           $FlowExpectedError: we do not allow to use 'string' in the 'Text'
           components but translations are exceptions.
         */}
-        {this.transformText(
+        {CaseTransform(
           this.replaceValues(translatedString, this.props.values),
           this.props.textTransform,
         )}

--- a/app/translations/src/TranslationFragment.js
+++ b/app/translations/src/TranslationFragment.js
@@ -2,6 +2,8 @@
 
 import * as React from 'react';
 
+import type { SupportedTransformationsType } from './transformations/CaseTransform';
+
 /**
  * Allows to concat multiple translations because it's not possible to nest
  * them. Usage:
@@ -17,6 +19,18 @@ import * as React from 'react';
  */
 export default class TranslationFragment extends React.Component<{|
   children: React.Node,
+  textTransform?: SupportedTransformationsType,
 |}> {
-  render = () => this.props.children;
+  render = () => {
+    if (this.props.children === undefined) {
+      throw new Error("'TranslationFragment' cannot be used without children.");
+    }
+
+    return React.Children.map(this.props.children, child =>
+      React.cloneElement(child, {
+        ...this.props,
+        children: null,
+      }),
+    );
+  };
 }

--- a/app/translations/src/__tests__/TranslationFragment.test.js
+++ b/app/translations/src/__tests__/TranslationFragment.test.js
@@ -1,0 +1,37 @@
+// @flow
+
+import * as React from 'react';
+import ShallowRenderer from 'react-test-renderer/shallow';
+
+import TranslationFragment from '../TranslationFragment';
+import DummyTranslation from '../DummyTranslation';
+
+const renderer = new ShallowRenderer();
+
+it('passes all props down to the children', () => {
+  expect(
+    renderer.render(
+      <TranslationFragment textTransform="uppercase">
+        <DummyTranslation id={1} />
+        <DummyTranslation id={2} />
+      </TranslationFragment>,
+    ),
+  ).toMatchSnapshot();
+});
+
+it('works without additional props', () => {
+  expect(
+    renderer.render(
+      <TranslationFragment>
+        <DummyTranslation id={1} />
+      </TranslationFragment>,
+    ),
+  ).toMatchSnapshot();
+});
+
+it('throws error for undefined children', () => {
+  expect(() =>
+    // $FlowExpectedError: Flow doesn't allow empty children either
+    renderer.render(<TranslationFragment />),
+  ).toThrowErrorMatchingSnapshot();
+});

--- a/app/translations/src/__tests__/__snapshots__/TranslationFragment.test.js.snap
+++ b/app/translations/src/__tests__/__snapshots__/TranslationFragment.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`passes all props down to the children 1`] = `
+Array [
+  <DummyTranslation
+    id={1}
+    textTransform="uppercase"
+  />,
+  <DummyTranslation
+    id={2}
+    textTransform="uppercase"
+  />,
+]
+`;
+
+exports[`throws error for undefined children 1`] = `"'TranslationFragment' cannot be used without children."`;
+
+exports[`works without additional props 1`] = `
+Array [
+  <DummyTranslation
+    id={1}
+  />,
+]
+`;

--- a/app/translations/src/transformations/CaseTransform.js
+++ b/app/translations/src/transformations/CaseTransform.js
@@ -1,0 +1,17 @@
+// @flow
+
+export type SupportedTransformationsType = 'lowercase' | 'uppercase';
+
+export default (
+  text: string,
+  transformation?: SupportedTransformationsType,
+): string => {
+  switch (transformation) {
+    case 'uppercase':
+      return text.toUpperCase();
+    case 'lowercase':
+      return text.toLowerCase();
+    default:
+      return text;
+  }
+};

--- a/app/translations/src/transformations/__tests__/CaseTransform.test.js
+++ b/app/translations/src/transformations/__tests__/CaseTransform.test.js
@@ -1,0 +1,32 @@
+// @flow
+
+import CaseTransform from '../CaseTransform';
+
+describe('uppercase', () => {
+  const transformation = 'uppercase';
+
+  it('works with normal text', () => {
+    expect(CaseTransform('text', transformation)).toBe('TEXT');
+  });
+
+  it('works with accents', () => {
+    expect(CaseTransform('ěščřžýáíéúü', transformation)).toBe('ĚŠČŘŽÝÁÍÉÚÜ');
+  });
+});
+
+describe('lowercase', () => {
+  const transformation = 'lowercase';
+
+  it('works with normal text', () => {
+    expect(CaseTransform('TEXT', transformation)).toBe('text');
+  });
+
+  it('works with accents', () => {
+    expect(CaseTransform('ĚŠČŘŽÝÁÍÉÚÜ', transformation)).toBe('ěščřžýáíéúü');
+  });
+});
+
+it('works with unknown transformation', () => {
+  // $FlowExpectedError: 'unknown' is not allowed transformation by Flow
+  expect(CaseTransform('TexT', 'unknown')).toBe('TexT');
+});


### PR DESCRIPTION
This props was used only in Translation component but it should be used
everywhere. Moreover the TranslationFragment should pass all props down.