### PR TITLE
ReadMore: disable ripple effect for link buttons

### DIFF
--- a/app/shared/src/ReadMore.js
+++ b/app/shared/src/ReadMore.js
@@ -39,7 +39,7 @@ const Link = ({
   style?: StylePropType,
 |}) => (
   <View style={styles.linkView}>
-    <Touchable onPress={handlePress}>
+    <Touchable onPress={handlePress} noRipple={true}>
       <Text style={[styles.linkText, style]}>
         <DummyTranslation id={label} />
       </Text>

--- a/app/shared/src/Touchable.js
+++ b/app/shared/src/Touchable.js
@@ -19,6 +19,9 @@ type Props = {|
   style?: StylePropType,
   onLongPress?: () => void,
   delayPressIn?: number,
+  // This will disable ripple effect completely and it will fallback to the
+  // opacity behavior.
+  noRipple?: boolean,
   // Should the ripple render outside of the view bounds?
   borderlessRipple?: boolean,
   rippleColor?: string,
@@ -43,6 +46,9 @@ export default class Touchable extends React.Component<Props> {
    * therefore only enable it on Android Lollipop and above.
    */
   supportsRippleEffect = () => {
+    if (this.props.noRipple === true) {
+      return false;
+    }
     return Platform.OS === 'android' && Platform.Version >= 21;
   };
 

--- a/app/shared/src/__tests__/Touchable.ripple.test.js
+++ b/app/shared/src/__tests__/Touchable.ripple.test.js
@@ -53,4 +53,15 @@ describe('Touchable with ripple effect', () => {
       ),
     ).toMatchSnapshot();
   });
+
+  it('is possible to turn ripple effect off', () => {
+    expect(
+      renderer.render(
+        // this should render TouchableOpacity
+        <Touchable noRipple={true} onPress={VoidAction}>
+          <DummyTranslation id="line" />
+        </Touchable>,
+      ),
+    ).toMatchSnapshot();
+  });
 });

--- a/app/shared/src/__tests__/__snapshots__/Touchable.ripple.test.js.snap
+++ b/app/shared/src/__tests__/__snapshots__/Touchable.ripple.test.js.snap
@@ -20,6 +20,21 @@ exports[`Touchable with ripple effect disables foreground in borderless mode 1`]
 </DummyTouchableNativeFeedback>
 `;
 
+exports[`Touchable with ripple effect is possible to turn ripple effect off 1`] = `
+<TouchableOpacity
+  activeOpacity={0.5}
+  borderlessRipple={false}
+  disabled={false}
+  noRipple={true}
+  onPress={[Function]}
+  rippleColor="rgba(0, 0, 0, .32)"
+>
+  <DummyTranslation
+    id="line"
+  />
+</TouchableOpacity>
+`;
+
 exports[`Touchable with ripple effect renders with foreground 1`] = `
 <DummyTouchableNativeFeedback
   background={undefined}


### PR DESCRIPTION
Android ripple effect is not always the best solution especially for
small button links. This new option will disable it:

```js
<Touchable noRipple={true}> ... </Touchable>
```

It should be used only rarely when it's appropriate or required.