### PR TITLE
Translations: fix propagation of props into 'TranslationFragment' children

### DIFF
--- a/app/hotels/src/filter/stars/StarsFilter.js
+++ b/app/hotels/src/filter/stars/StarsFilter.js
@@ -70,10 +70,7 @@ export default class StarsFilter extends React.Component<Props, State> {
       <TranslationFragment>
         {stars.includes(0) && (
           <TranslationFragment>
-            <Translation
-              id="HotelsSearch.Filter.StarsFilter.Unrated"
-              key="unratedTranslation"
-            />
+            <Translation id="HotelsSearch.Filter.StarsFilter.Unrated" />
             {stars.length > 1 && <DummyTranslation id="," />}
           </TranslationFragment>
         )}

--- a/app/translations/src/__tests__/TranslationFragment.test.js
+++ b/app/translations/src/__tests__/TranslationFragment.test.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 import testRenderer from 'react-test-renderer';
+import { Text } from '@kiwicom/react-native-app-shared';
 
 import TranslationFragment from '../TranslationFragment';
 import DummyTranslation from '../DummyTranslation';
@@ -38,11 +39,10 @@ it('throws error for undefined children', () => {
 });
 
 it('works with conditionals', () => {
-  const int = 1;
   expect(
     testRenderer.create(
       <TranslationFragment>
-        {int === 0 && <DummyTranslation id="I should not render" />}
+        {false && <DummyTranslation id="I should NOT render" />}
         <DummyTranslation id="I should render" />
       </TranslationFragment>,
     ),
@@ -55,6 +55,46 @@ it('works with string as child', () => {
       <TranslationFragment>
         this is a string
         <DummyTranslation id="I should render" />
+      </TranslationFragment>,
+    ),
+  ).toMatchSnapshot();
+});
+
+it('works with nested fragments', () => {
+  expect(
+    testRenderer.create(
+      <TranslationFragment textTransform="lowercase">
+        <DummyTranslation id="level AAA.1" />
+        <TranslationFragment>
+          {/* these translations (vv) are going to be lowercased as well */}
+          <DummyTranslation id="level BBB.1" />
+          <DummyTranslation id="level BBB.2" />
+        </TranslationFragment>
+        <DummyTranslation id="level AAA.2" />
+      </TranslationFragment>,
+    ),
+  ).toMatchSnapshot();
+});
+
+it('overwrites the previous textTransform property', () => {
+  expect(
+    testRenderer.create(
+      <TranslationFragment textTransform="lowercase">
+        <TranslationFragment textTransform="uppercase">
+          <DummyTranslation id="this should be uppercased" />
+        </TranslationFragment>
+      </TranslationFragment>,
+    ),
+  ).toMatchSnapshot();
+});
+
+it('transforms only translations friendly components', () => {
+  expect(
+    testRenderer.create(
+      <TranslationFragment textTransform="uppercase">
+        <DummyTranslation id="this is going to be uppercased" />
+        {/* $FlowExpectedError: string is not allowed in the Text but I want to test it */}
+        <Text>this is going to stay lowercased</Text>
       </TranslationFragment>,
     ),
   ).toMatchSnapshot();

--- a/app/translations/src/__tests__/__snapshots__/TranslationFragment.test.js.snap
+++ b/app/translations/src/__tests__/__snapshots__/TranslationFragment.test.js.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`overwrites the previous textTransform property 1`] = `
+<Text
+  accessible={true}
+  allowFontScaling={true}
+  ellipsizeMode="tail"
+  style={
+    Array [
+      Object {
+        "color": "#30363d",
+        "fontSize": 14,
+        "fontWeight": "normal",
+        "letterSpacing": -0.15,
+      },
+      undefined,
+    ]
+  }
+>
+  THIS SHOULD BE UPPERCASED
+</Text>
+`;
+
 exports[`passes all props down to the children 1`] = `
 Array [
   <DummyTranslation
@@ -14,6 +35,47 @@ Array [
 `;
 
 exports[`throws error for undefined children 1`] = `"'TranslationFragment' cannot be used without children."`;
+
+exports[`transforms only translations friendly components 1`] = `
+Array [
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "#30363d",
+          "fontSize": 14,
+          "fontWeight": "normal",
+          "letterSpacing": -0.15,
+        },
+        undefined,
+      ]
+    }
+  >
+    THIS IS GOING TO BE UPPERCASED
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "#30363d",
+          "fontSize": 14,
+          "fontWeight": "normal",
+          "letterSpacing": -0.15,
+        },
+        undefined,
+      ]
+    }
+  >
+    this is going to stay lowercased
+  </Text>,
+]
+`;
 
 exports[`works with conditionals 1`] = `
 <Text
@@ -34,6 +96,83 @@ exports[`works with conditionals 1`] = `
 >
   I should render
 </Text>
+`;
+
+exports[`works with nested fragments 1`] = `
+Array [
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "#30363d",
+          "fontSize": 14,
+          "fontWeight": "normal",
+          "letterSpacing": -0.15,
+        },
+        undefined,
+      ]
+    }
+  >
+    level aaa.1
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "#30363d",
+          "fontSize": 14,
+          "fontWeight": "normal",
+          "letterSpacing": -0.15,
+        },
+        undefined,
+      ]
+    }
+  >
+    level bbb.1
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "#30363d",
+          "fontSize": 14,
+          "fontWeight": "normal",
+          "letterSpacing": -0.15,
+        },
+        undefined,
+      ]
+    }
+  >
+    level bbb.2
+  </Text>,
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    ellipsizeMode="tail"
+    style={
+      Array [
+        Object {
+          "color": "#30363d",
+          "fontSize": 14,
+          "fontWeight": "normal",
+          "letterSpacing": -0.15,
+        },
+        undefined,
+      ]
+    }
+  >
+    level aaa.2
+  </Text>,
+]
 `;
 
 exports[`works with string as child 1`] = `


### PR DESCRIPTION
TranslationFragment passed all props into children except children
itself (to prevent children duplication). However this means that it was
 not possible to deeply nest TranslationFragment components but we are
 doing it in our code. This change fixes it.