### PR TITLE
Rename '@kiwicom/react-native-app-*' packages to '@kiwicom/mobile-*'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,12 +55,12 @@ module.exports = {
               'TouchableOpacity', // Touchable
             ],
             message:
-              "Please use '@kiwicom/react-native-app-shared' package instead.",
+              "Please use '@kiwicom/mobile-shared' package instead.",
           },
           {
             name: 'react-native-read-more-text', // ReadMore
             message:
-              "Please use '@kiwicom/react-native-app-shared' package instead.",
+              "Please use '@kiwicom/mobile-shared' package instead.",
           },
           {
             name: 'react-navigation',
@@ -68,7 +68,7 @@ module.exports = {
               'StackNavigator', // StackNavigator
             ],
             message:
-              "Please use '@kiwicom/react-native-app-navigation' package instead.",
+              "Please use '@kiwicom/mobile-navigation' package instead.",
           },
         ],
       },

--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ This project uses [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/
 ├── .github/                    - GitHub templates (for PR, issues, contributing)
 ├── android/                    - native code for Android
 ├── app/
-│   ├── config/                 - @kiwicom/react-native-app-config
-│   │── core/                   - @kiwicom/react-native-app-core (core package)
+│   ├── config/                 - @kiwicom/mobile-config
+│   │── core/                   - @kiwicom/mobile-core (core package)
 │   ├── hotels/                 - @kiwicom/react-native-app-hotels
-│   ├── navigation/             - @kiwicom/react-native-app-navigation
-│   ├── redux/                  - @kiwicom/react-native-app-redux
-│   └── relay/                  - @kiwicom/react-native-app-relay
-│   └── shared/                 - @kiwicom/react-native-app-shared (formerly common)
+│   ├── navigation/             - @kiwicom/mobile-navigation
+│   ├── redux/                  - @kiwicom/mobile-redux
+│   └── relay/                  - @kiwicom/mobile-relay
+│   └── shared/                 - @kiwicom/mobile-shared (formerly common)
 ├── ios/                        - native code for iOS
 ├── scripts/                    - support scripts for the whole monorepo
 └── schema.graphql              - GraphQL schema of the backend server
@@ -174,7 +174,7 @@ const Type = {
 Usage:
 
 ```js
-import { Logger } from '@kiwicom/react-native-app-shared';
+import { Logger } from '@kiwicom/mobile-shared';
 
 Logger.ancillaryDisplayed(Logger.type.ANCILLARY_STEP_DETAILS);
 Logger.ancillaryPurchased(Logger.type.ANCILLARY_STEP_RESULTS);
@@ -188,7 +188,7 @@ It exposes one method
 Usage:
 
 ```js
-import { Translate } from '@kiwicom/react-native-app-shared';
+import { Translate } from '@kiwicom/mobile-shared';
 
 const someString = Translate('translation.key.to.translate');
 ```
@@ -213,7 +213,7 @@ NativeModules.RNColors = {
 Usage:
 
 ```js
-import { Color } from '@kiwicom/react-native-app-shared';
+import { Color } from '@kiwicom/mobile-shared';
 
 const color = Color.brand;
 ```
@@ -226,7 +226,7 @@ It exposes one method
 Usage:
 
 ```js
-import { CurrencyFormatter } from '@kiwicom/react-native-app-shared';
+import { CurrencyFormatter } from '@kiwicom/mobile-shared';
 
 const priceInEuros = 500.34;
 const currencyCode = 'NOK';
@@ -312,22 +312,22 @@ This application consists of independent packages so they can be reused or repla
 1. install Redux dependency (called in the `hotels` package scope):
 
 ```
-yarn add @kiwicom/react-native-app-redux
+yarn add @kiwicom/mobile-redux
 ```
 
 2. register reducers:
 
 ```js
-import { injectAsyncReducer, store } from '@kiwicom/react-native-app-redux';
+import { injectAsyncReducer, store } from '@kiwicom/mobile-redux';
 import HotelsReducer from './src/HotelsReducer';
 
 injectAsyncReducer(store, 'hotels', HotelsReducer);
 ```
 
-We currently **do not** officially support calling actions on reducers outside of one package. This means that you should always work with actions and reducers from `HotelReducer`. This should be in most of the scenarios good enough. You must use `connect` function from `@kiwicom/react-native-app-redux` package in order to connect React component to the Redux store:
+We currently **do not** officially support calling actions on reducers outside of one package. This means that you should always work with actions and reducers from `HotelReducer`. This should be in most of the scenarios good enough. You must use `connect` function from `@kiwicom/mobile-redux` package in order to connect React component to the Redux store:
 
 ```js
-import { connect } from '@kiwicom/react-native-app-redux';
+import { connect } from '@kiwicom/mobile-redux';
 
 export default connect(select, actions)(ComponentWithoutStore);
 ```
@@ -437,7 +437,7 @@ rm -rf node_modules/ && yarn cache clean && yarn install
 
 For more information please visit this issue: https://github.com/facebook/react-native/issues/14382
 
-### Cannot resolve module '@kiwicom/react-native-app-<module>'
+### Cannot resolve module '@kiwicom/mobile-<module>'
 
 #### Symptoms:
 

--- a/app/accessibility/package.json
+++ b/app/accessibility/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kiwicom/react-native-app-accessibility",
+  "name": "@kiwicom/mobile-accessibility",
   "version": "0.0.0",
   "private": true,
   "main": "index.js"

--- a/app/config/package.json
+++ b/app/config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kiwicom/react-native-app-config",
+  "name": "@kiwicom/mobile-config",
   "version": "0.0.0",
   "private": true,
   "main": "index.js"

--- a/app/core/package.json
+++ b/app/core/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@kiwicom/react-native-app-core",
+  "name": "@kiwicom/mobile-core",
   "version": "0.0.0",
   "private": true,
   "dependencies": {
     "@kiwicom/react-native-app-hotels": "^0",
-    "@kiwicom/react-native-app-navigation": "^0",
-    "@kiwicom/react-native-app-redux": "^0",
-    "@kiwicom/react-native-app-relay": "^0",
-    "@kiwicom/react-native-app-shared": "^0"
+    "@kiwicom/mobile-navigation": "^0",
+    "@kiwicom/mobile-redux": "^0",
+    "@kiwicom/mobile-relay": "^0",
+    "@kiwicom/mobile-shared": "^0"
   }
 }

--- a/app/core/src/components/authentication/EmailLoginForm.js
+++ b/app/core/src/components/authentication/EmailLoginForm.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { TextInput, Button } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { TextInput, Button } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import LoginMutation, { type Callback } from './mutation/Login';
 import { createAccessToken, type AccessToken } from '../../types/AccessToken';

--- a/app/core/src/components/authentication/Login.js
+++ b/app/core/src/components/authentication/Login.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { CenteredView } from '@kiwicom/react-native-app-shared';
+import { CenteredView } from '@kiwicom/mobile-shared';
 
 import EmailLoginForm from './EmailLoginForm';
 

--- a/app/core/src/components/authentication/Logout.js
+++ b/app/core/src/components/authentication/Logout.js
@@ -1,9 +1,9 @@
 // @flow
 
 import * as React from 'react';
-import { connect } from '@kiwicom/react-native-app-redux';
-import { LinkButton } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { connect } from '@kiwicom/mobile-redux';
+import { LinkButton } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 type Props = {|
   onLogout: () => void,

--- a/app/core/src/components/authentication/mutation/Login.js
+++ b/app/core/src/components/authentication/mutation/Login.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { graphql } from 'react-relay';
-import { commitMutation } from '@kiwicom/react-native-app-relay';
+import { commitMutation } from '@kiwicom/mobile-relay';
 
 import type {
   LoginMutationVariables,

--- a/app/core/src/components/relay/PrivateApiRenderer.js
+++ b/app/core/src/components/relay/PrivateApiRenderer.js
@@ -1,11 +1,11 @@
 // @flow
 
 import * as React from 'react';
-import { connect } from '@kiwicom/react-native-app-redux';
+import { connect } from '@kiwicom/mobile-redux';
 import {
   PrivateApiRenderer as PrivateApiRendererOriginal,
   type QueryRendererProps,
-} from '@kiwicom/react-native-app-relay';
+} from '@kiwicom/mobile-relay';
 
 import Login from '../authentication/Login';
 import type { UserReducerState } from '../../services/redux/UserReducer';

--- a/app/core/src/navigation/HomepageStack.js
+++ b/app/core/src/navigation/HomepageStack.js
@@ -6,8 +6,8 @@ import {
   HeaderTitle,
   StackNavigator,
   StackNavigatorOptions,
-} from '@kiwicom/react-native-app-navigation';
-import { Translation } from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-navigation';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import Homepage from '../screens/homepage/Homepage';
 

--- a/app/core/src/navigation/index.js
+++ b/app/core/src/navigation/index.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { withMappedNavigationAndConfigProps as withMappedProps } from 'react-navigation-props-mapper';
-import { ReduxContext } from '@kiwicom/react-native-app-redux';
-import { StackNavigator } from '@kiwicom/react-native-app-navigation';
+import { ReduxContext } from '@kiwicom/mobile-redux';
+import { StackNavigator } from '@kiwicom/mobile-navigation';
 
 import HomepageStack from './HomepageStack';
 import UserReducer from '../services/redux/UserReducer';

--- a/app/core/src/screens/HotelsPackageWrapper.js
+++ b/app/core/src/screens/HotelsPackageWrapper.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { HotelsStandalonePackage } from '@kiwicom/react-native-app-hotels';
-import { type NavigationType } from '@kiwicom/react-native-app-navigation';
+import { type NavigationType } from '@kiwicom/mobile-navigation';
 
 import Config from '../../config/application';
 

--- a/app/core/src/screens/SingleHotelPackageWrapper.js
+++ b/app/core/src/screens/SingleHotelPackageWrapper.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { SingleHotelStandalonePackage } from '@kiwicom/react-native-app-hotels';
-import { type NavigationType } from '@kiwicom/react-native-app-navigation';
-import { DateFormatter } from '@kiwicom/react-native-app-localization';
+import { type NavigationType } from '@kiwicom/mobile-navigation';
+import { DateFormatter } from '@kiwicom/mobile-localization';
 
 import Config from '../../config/application';
 

--- a/app/core/src/screens/homepage/Homepage.js
+++ b/app/core/src/screens/homepage/Homepage.js
@@ -2,9 +2,9 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { Button, Layout } from '@kiwicom/react-native-app-shared';
-import { type NavigationType } from '@kiwicom/react-native-app-navigation';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Button, Layout } from '@kiwicom/mobile-shared';
+import { type NavigationType } from '@kiwicom/mobile-navigation';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import Logout from '../../components/authentication/Logout';
 

--- a/app/hotels/package.json
+++ b/app/hotels/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "main": "index.js",
   "dependencies": {
-    "@kiwicom/react-native-app-config": "^0",
-    "@kiwicom/react-native-app-redux": "^0",
-    "@kiwicom/react-native-app-shared": "^0",
+    "@kiwicom/mobile-config": "^0",
+    "@kiwicom/mobile-redux": "^0",
+    "@kiwicom/mobile-shared": "^0",
     "geolib": "2.0.24",
     "idx": "2.2.0",
     "lodash": "^4.17.4",
@@ -18,7 +18,7 @@
     "react-native-tooltips": "^0.0.4"
   },
   "devDependencies": {
-    "@kiwicom/react-native-app-playground": "^0",
+    "@kiwicom/mobile-playground": "^0",
     "mockdate": "^2.0.2"
   }
 }

--- a/app/hotels/src/GraphQLSanitizers.js
+++ b/app/hotels/src/GraphQLSanitizers.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { DateFormatter } from '@kiwicom/react-native-app-localization';
+import { DateFormatter } from '@kiwicom/mobile-localization';
 
 export const sanitizeDate = (input: ?Date): ?string =>
   input && DateFormatter(input).format('YYYY-MM-DD');

--- a/app/hotels/src/HotelsReducer.js
+++ b/app/hotels/src/HotelsReducer.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { DateFormatter } from '@kiwicom/react-native-app-localization';
+import { DateFormatter } from '@kiwicom/mobile-localization';
 
 import type {
   OnChangeSearchParams,

--- a/app/hotels/src/allHotels/AllHotels.js
+++ b/app/hotels/src/allHotels/AllHotels.js
@@ -4,13 +4,9 @@ import * as React from 'react';
 import { ScrollView, Keyboard } from 'react-native';
 import idx from 'idx';
 import { graphql } from 'react-relay';
-import { PublicApiRenderer } from '@kiwicom/react-native-app-relay';
-import {
-  Layout,
-  AppStateChange,
-  StyleSheet,
-} from '@kiwicom/react-native-app-shared';
-import { connect } from '@kiwicom/react-native-app-redux';
+import { PublicApiRenderer } from '@kiwicom/mobile-relay';
+import { Layout, AppStateChange, StyleSheet } from '@kiwicom/mobile-shared';
+import { connect } from '@kiwicom/mobile-redux';
 
 import AllHotelsSearch from './AllHotelsSearch';
 import SearchForm from './searchForm/SearchForm';

--- a/app/hotels/src/allHotels/AllHotelsSearch.js
+++ b/app/hotels/src/allHotels/AllHotelsSearch.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { graphql } from 'react-relay';
-import { PublicApiRenderer } from '@kiwicom/react-native-app-relay';
-import { connect } from '@kiwicom/react-native-app-redux';
+import { PublicApiRenderer } from '@kiwicom/mobile-relay';
+import { connect } from '@kiwicom/mobile-redux';
 
 import AllHotelsSearchList from './AllHotelsSearchList';
 import { handleOpenSingleHotel } from '../singleHotel';

--- a/app/hotels/src/allHotels/AllHotelsSearchList.js
+++ b/app/hotels/src/allHotels/AllHotelsSearchList.js
@@ -4,9 +4,9 @@ import * as React from 'react';
 import idx from 'idx';
 import { createPaginationContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
-import { Logger, GeneralError } from '@kiwicom/react-native-app-shared';
-import { connect } from '@kiwicom/react-native-app-redux';
-import type { RelayPaginationProp } from '@kiwicom/react-native-app-relay';
+import { Logger, GeneralError } from '@kiwicom/mobile-shared';
+import { connect } from '@kiwicom/mobile-redux';
+import type { RelayPaginationProp } from '@kiwicom/mobile-relay';
 
 import AllHotelsSearchRow from './AllHotelsSearchRow';
 import LoadMoreButton from './LoadMoreButton';

--- a/app/hotels/src/allHotels/AllHotelsSearchRow.js
+++ b/app/hotels/src/allHotels/AllHotelsSearchRow.js
@@ -4,11 +4,7 @@ import * as React from 'react';
 import idx from 'idx';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
-import {
-  SimpleCard,
-  NetworkImage,
-  StyleSheet,
-} from '@kiwicom/react-native-app-shared';
+import { SimpleCard, NetworkImage, StyleSheet } from '@kiwicom/mobile-shared';
 
 import HotelTitle from './HotelTitle';
 import HotelReviewScore from './HotelReviewScore';

--- a/app/hotels/src/allHotels/HotelDistance.js
+++ b/app/hotels/src/allHotels/HotelDistance.js
@@ -3,8 +3,8 @@
 import * as React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import idx from 'idx';
-import { StyleSheet, Text, Color } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { StyleSheet, Text, Color } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import type { HotelDistance_hotel } from './__generated__/HotelDistance_hotel.graphql';
 

--- a/app/hotels/src/allHotels/HotelReviewScore.js
+++ b/app/hotels/src/allHotels/HotelReviewScore.js
@@ -3,11 +3,7 @@
 import * as React from 'react';
 import idx from 'idx';
 import { createFragmentContainer, graphql } from 'react-relay';
-import {
-  AdaptableBadge,
-  StyleSheet,
-  Color,
-} from '@kiwicom/react-native-app-shared';
+import { AdaptableBadge, StyleSheet, Color } from '@kiwicom/mobile-shared';
 
 import type { HotelReviewScore_hotel } from './__generated__/HotelReviewScore_hotel.graphql';
 

--- a/app/hotels/src/allHotels/HotelTitle.js
+++ b/app/hotels/src/allHotels/HotelTitle.js
@@ -4,14 +4,8 @@ import * as React from 'react';
 import idx from 'idx';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
-import {
-  Color,
-  Price,
-  Stars,
-  Text,
-  StyleSheet,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Color, Price, Stars, Text, StyleSheet } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import Distance from './HotelDistance';
 import type { HotelTitle as HotelTitleType } from './__generated__/HotelTitle.graphql';

--- a/app/hotels/src/allHotels/LoadMoreButton.js
+++ b/app/hotels/src/allHotels/LoadMoreButton.js
@@ -2,12 +2,8 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import {
-  IconLoading,
-  LinkButton,
-  StyleSheet,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { IconLoading, LinkButton, StyleSheet } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 type Props = {|
   isLoading: boolean,

--- a/app/hotels/src/allHotels/__tests__/LoadMoreButton.test.js
+++ b/app/hotels/src/allHotels/__tests__/LoadMoreButton.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import LoadMoreButton from '../LoadMoreButton';
 

--- a/app/hotels/src/allHotels/searchForm/DateInput.js
+++ b/app/hotels/src/allHotels/searchForm/DateInput.js
@@ -2,12 +2,8 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { DateFormatter } from '@kiwicom/react-native-app-localization';
-import {
-  DatePicker,
-  StyleSheet,
-  TextIcon,
-} from '@kiwicom/react-native-app-shared';
+import { DateFormatter } from '@kiwicom/mobile-localization';
+import { DatePicker, StyleSheet, TextIcon } from '@kiwicom/mobile-shared';
 
 import type { OnChangeSearchParams } from './SearchParametersType';
 

--- a/app/hotels/src/allHotels/searchForm/LocationButton.js
+++ b/app/hotels/src/allHotels/searchForm/LocationButton.js
@@ -2,13 +2,8 @@
 
 import * as React from 'react';
 import { View, TouchableWithoutFeedback } from 'react-native';
-import {
-  Text,
-  StyleSheet,
-  Icon,
-  Color,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Text, StyleSheet, Icon, Color } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 const styles = StyleSheet.create({
   locationButton: {

--- a/app/hotels/src/allHotels/searchForm/SearchForm.js
+++ b/app/hotels/src/allHotels/searchForm/SearchForm.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { Color, Logger, StyleSheet } from '@kiwicom/react-native-app-shared';
+import { Color, Logger, StyleSheet } from '@kiwicom/mobile-shared';
 import { View } from 'react-native';
 
 import DateInput from './DateInput';

--- a/app/hotels/src/allHotels/searchForm/__tests__/DateInput.test.js
+++ b/app/hotels/src/allHotels/searchForm/__tests__/DateInput.test.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import renderer from 'react-test-renderer';
-import { DateFormatter } from '@kiwicom/react-native-app-localization';
+import { DateFormatter } from '@kiwicom/mobile-localization';
 
 import DateInput, { checkinAndCheckoutToDate } from '../DateInput';
 

--- a/app/hotels/src/allHotels/searchForm/__tests__/SearchForm.test.js
+++ b/app/hotels/src/allHotels/searchForm/__tests__/SearchForm.test.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import renderer from 'react-test-renderer';
 import ShallowRenderer from 'react-test-renderer/shallow';
-import { DatePicker } from '@kiwicom/react-native-app-shared';
+import { DatePicker } from '@kiwicom/mobile-shared';
 import MockDate from 'mockdate';
 
 import SearchForm from '../SearchForm';

--- a/app/hotels/src/allHotels/searchForm/guests/AgeControl.js
+++ b/app/hotels/src/allHotels/searchForm/guests/AgeControl.js
@@ -8,8 +8,8 @@ import {
   AgePicker,
   Icon,
   Text,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 type Props = {|
   label: string,

--- a/app/hotels/src/allHotels/searchForm/guests/ChildrenAgesControl.js
+++ b/app/hotels/src/allHotels/searchForm/guests/ChildrenAgesControl.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { Color, StyleSheet } from '@kiwicom/react-native-app-shared';
+import { Color, StyleSheet } from '@kiwicom/mobile-shared';
 
 import AgeControl from './AgeControl';
 import type { ChildAge } from './GuestsTypes';

--- a/app/hotels/src/allHotels/searchForm/guests/ErrorMessage.js
+++ b/app/hotels/src/allHotels/searchForm/guests/ErrorMessage.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { Text, Color, StyleSheet } from '@kiwicom/react-native-app-shared';
-import { type TranslationType } from '@kiwicom/react-native-app-localization';
+import { Text, Color, StyleSheet } from '@kiwicom/mobile-shared';
+import { type TranslationType } from '@kiwicom/mobile-localization';
 
 type Props = {|
   children: TranslationType,

--- a/app/hotels/src/allHotels/searchForm/guests/Guests.js
+++ b/app/hotels/src/allHotels/searchForm/guests/Guests.js
@@ -8,8 +8,8 @@ import {
   StyleSheet,
   Icon,
   Text,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import type { RoomConfigurationType } from '../SearchParametersType';
 

--- a/app/hotels/src/allHotels/searchForm/guests/GuestsModal.js
+++ b/app/hotels/src/allHotels/searchForm/guests/GuestsModal.js
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react';
 import { View, ScrollView, InteractionManager } from 'react-native';
-import { Text, StyleSheet, Color } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Text, StyleSheet, Color } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import ChildrenAgesControl from './ChildrenAgesControl';
 import type {

--- a/app/hotels/src/allHotels/searchForm/guests/GuestsNumberControls.js
+++ b/app/hotels/src/allHotels/searchForm/guests/GuestsNumberControls.js
@@ -2,11 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import {
-  StyleSheet,
-  Color,
-  NumberControl,
-} from '@kiwicom/react-native-app-shared';
+import { StyleSheet, Color, NumberControl } from '@kiwicom/mobile-shared';
 
 const styles = StyleSheet.create({
   numberPickerContainer: {

--- a/app/hotels/src/allHotels/searchForm/guests/__tests__/ChildrenAgesControl.test.js
+++ b/app/hotels/src/allHotels/searchForm/guests/__tests__/ChildrenAgesControl.test.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import renderer from 'react-test-renderer';
-import { AgePicker } from '@kiwicom/react-native-app-shared';
+import { AgePicker } from '@kiwicom/mobile-shared';
 
 import ChildrenAgesControl from '../ChildrenAgesControl';
 import AgeControl from '../AgeControl';

--- a/app/hotels/src/allHotels/searchForm/locationPicker/LocationPicker.js
+++ b/app/hotels/src/allHotels/searchForm/locationPicker/LocationPicker.js
@@ -7,10 +7,10 @@ import {
   Color,
   TextInput,
   WithStorage,
-} from '@kiwicom/react-native-app-shared';
-import { PublicApiRenderer } from '@kiwicom/react-native-app-relay';
+} from '@kiwicom/mobile-shared';
+import { PublicApiRenderer } from '@kiwicom/mobile-relay';
 import { graphql } from 'react-relay';
-import { connect } from '@kiwicom/react-native-app-redux';
+import { connect } from '@kiwicom/mobile-redux';
 
 import RecentSearches from './RecentSearches';
 import SuggestionList from './SuggestionList';

--- a/app/hotels/src/allHotels/searchForm/locationPicker/RecentSearchItem.js
+++ b/app/hotels/src/allHotels/searchForm/locationPicker/RecentSearchItem.js
@@ -1,13 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import {
-  Touchable,
-  StyleSheet,
-  Text,
-  Color,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Touchable, StyleSheet, Text, Color } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import Row from './Row';
 

--- a/app/hotels/src/allHotels/searchForm/locationPicker/RecentSearches.js
+++ b/app/hotels/src/allHotels/searchForm/locationPicker/RecentSearches.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { View, FlatList, Keyboard } from 'react-native';
-import { StyleSheet } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { StyleSheet } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import RecentSearchItem from './RecentSearchItem';
 

--- a/app/hotels/src/allHotels/searchForm/locationPicker/Row.js
+++ b/app/hotels/src/allHotels/searchForm/locationPicker/Row.js
@@ -1,11 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import {
-  StyleSheet,
-  Color,
-  type StylePropType,
-} from '@kiwicom/react-native-app-shared';
+import { StyleSheet, Color, type StylePropType } from '@kiwicom/mobile-shared';
 import { View } from 'react-native';
 
 const styles = StyleSheet.create({

--- a/app/hotels/src/allHotels/searchForm/locationPicker/SuggestionList.js
+++ b/app/hotels/src/allHotels/searchForm/locationPicker/SuggestionList.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { FlatList, View, Keyboard } from 'react-native';
 import idx from 'idx';
-import { StyleSheet } from '@kiwicom/react-native-app-shared';
+import { StyleSheet } from '@kiwicom/mobile-shared';
 import { createFragmentContainer, graphql } from 'react-relay';
 
 import SuggestionListItem from './SuggestionListItem';

--- a/app/hotels/src/allHotels/searchForm/locationPicker/SuggestionListItem.js
+++ b/app/hotels/src/allHotels/searchForm/locationPicker/SuggestionListItem.js
@@ -1,13 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import {
-  Text,
-  StyleSheet,
-  Color,
-  Touchable,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Text, StyleSheet, Color, Touchable } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 import idx from 'idx';
 
 import Row from './Row';

--- a/app/hotels/src/allHotels/searchForm/locationPicker/YourLocation.js
+++ b/app/hotels/src/allHotels/searchForm/locationPicker/YourLocation.js
@@ -2,13 +2,8 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import {
-  Text,
-  Icon,
-  StyleSheet,
-  Color,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Text, Icon, StyleSheet, Color } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 const styles = StyleSheet.create({
   container: {

--- a/app/hotels/src/allHotels/searchForm/locationPicker/__tests__/RecentSearches.test.js
+++ b/app/hotels/src/allHotels/searchForm/locationPicker/__tests__/RecentSearches.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import RecentSearches from '../RecentSearches';
 

--- a/app/hotels/src/allHotels/searchForm/locationPicker/__tests__/SuggestionList.test.js
+++ b/app/hotels/src/allHotels/searchForm/locationPicker/__tests__/SuggestionList.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import { SuggestionList } from '../SuggestionList';
 

--- a/app/hotels/src/appRegistry/RootComponent.js
+++ b/app/hotels/src/appRegistry/RootComponent.js
@@ -2,13 +2,9 @@
 
 import * as React from 'react';
 import { View, NativeModules } from 'react-native';
-import { ReduxContext } from '@kiwicom/react-native-app-redux';
-import { ConfigReducer } from '@kiwicom/react-native-app-config';
-import {
-  Device,
-  type OnLayout,
-  StyleSheet,
-} from '@kiwicom/react-native-app-shared';
+import { ReduxContext } from '@kiwicom/mobile-redux';
+import { ConfigReducer } from '@kiwicom/mobile-config';
+import { Device, type OnLayout, StyleSheet } from '@kiwicom/mobile-shared';
 
 import FiltersReducer from '../filter/FiltersReducer';
 import HotelsReducer from '../HotelsReducer';

--- a/app/hotels/src/appRegistry/SingleHotelStandalonePackage.js
+++ b/app/hotels/src/appRegistry/SingleHotelStandalonePackage.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { DateFormatter } from '@kiwicom/react-native-app-localization';
+import { DateFormatter } from '@kiwicom/mobile-localization';
 
 import RootComponent from './RootComponent';
 import SingleHotelStack from '../navigation/singleHotel/SingleHotelStack';

--- a/app/hotels/src/filter/FilterButton.js
+++ b/app/hotels/src/filter/FilterButton.js
@@ -2,13 +2,8 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import {
-  Button,
-  Color,
-  Icon,
-  StyleSheet,
-} from '@kiwicom/react-native-app-shared';
-import type { TranslationType } from '@kiwicom/react-native-app-localization';
+import { Button, Color, Icon, StyleSheet } from '@kiwicom/mobile-shared';
+import type { TranslationType } from '@kiwicom/mobile-localization';
 
 type Props = {
   title: TranslationType,

--- a/app/hotels/src/filter/FilterStripe.js
+++ b/app/hotels/src/filter/FilterStripe.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { ScrollView, View } from 'react-native';
-import { connect } from '@kiwicom/react-native-app-redux';
-import { StyleSheet } from '@kiwicom/react-native-app-shared';
+import { connect } from '@kiwicom/mobile-redux';
+import { StyleSheet } from '@kiwicom/mobile-shared';
 
 import StarsFilter from './stars/StarsFilter';
 import PriceFilter from './price/PriceFilter';

--- a/app/hotels/src/filter/__tests__/FilterButton.test.js
+++ b/app/hotels/src/filter/__tests__/FilterButton.test.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
-import { Icon } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Icon } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import FilterButton from '../FilterButton';
 

--- a/app/hotels/src/filter/freeCancellation/FreeCancellationFilter.js
+++ b/app/hotels/src/filter/freeCancellation/FreeCancellationFilter.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import FilterButton from '../FilterButton';
 import type { OnChangeFilterParams } from '../FilterParametersType';

--- a/app/hotels/src/filter/hotelFacilities/HotelFacilitiesFilter.js
+++ b/app/hotels/src/filter/hotelFacilities/HotelFacilitiesFilter.js
@@ -2,10 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import {
-  Translation,
-  TranslationFragment,
-} from '@kiwicom/react-native-app-localization';
+import { Translation, TranslationFragment } from '@kiwicom/mobile-localization';
 
 import HotelFacilitiesPopup from './HotelFacilitiesPopup';
 import FilterButton from '../FilterButton';

--- a/app/hotels/src/filter/hotelFacilities/HotelFacilitiesPopup.js
+++ b/app/hotels/src/filter/hotelFacilities/HotelFacilitiesPopup.js
@@ -9,8 +9,8 @@ import {
   Icon,
   StyleSheet,
   Text,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 type Props = {|
   facilities: string[],

--- a/app/hotels/src/filter/price/PriceFilter.js
+++ b/app/hotels/src/filter/price/PriceFilter.js
@@ -2,9 +2,9 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { connect } from '@kiwicom/react-native-app-redux';
-import { Icon, Color } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { connect } from '@kiwicom/mobile-redux';
+import { Icon, Color } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import PricePopup from './PricePopup';
 import FilterButton from '../FilterButton';

--- a/app/hotels/src/filter/price/PricePopup.js
+++ b/app/hotels/src/filter/price/PricePopup.js
@@ -1,13 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import {
-  Text,
-  ButtonPopup,
-  Slider,
-  Price,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Text, ButtonPopup, Slider, Price } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 type Props = {|
   onClose: () => void,

--- a/app/hotels/src/filter/score/ScoreFilter.js
+++ b/app/hotels/src/filter/score/ScoreFilter.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { Icon, Color } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Icon, Color } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import ScorePopup from './ScorePopup';
 import FilterButton from '../FilterButton';

--- a/app/hotels/src/filter/score/ScorePopup.js
+++ b/app/hotels/src/filter/score/ScorePopup.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { Text, ButtonPopup, Slider } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Text, ButtonPopup, Slider } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 type Props = {|
   onClose: () => void,

--- a/app/hotels/src/filter/stars/StarsCheckbox.js
+++ b/app/hotels/src/filter/stars/StarsCheckbox.js
@@ -8,7 +8,7 @@ import {
   StyleSheet,
   Text,
   type StylePropType,
-} from '@kiwicom/react-native-app-shared';
+} from '@kiwicom/mobile-shared';
 
 type Props = {|
   onPress: () => void,

--- a/app/hotels/src/filter/stars/StarsFilter.js
+++ b/app/hotels/src/filter/stars/StarsFilter.js
@@ -2,12 +2,12 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { Icon, Color } from '@kiwicom/react-native-app-shared';
+import { Icon, Color } from '@kiwicom/mobile-shared';
 import {
   Translation,
   TranslationFragment,
   type TranslationType,
-} from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-localization';
 
 import StarsPopup from './StarsPopup';
 import FilterButton from '../FilterButton';

--- a/app/hotels/src/filter/stars/StarsPopup.js
+++ b/app/hotels/src/filter/stars/StarsPopup.js
@@ -7,8 +7,8 @@ import {
   Color,
   Checkbox,
   Text,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import StarsCheckbox from './StarsCheckbox';
 

--- a/app/hotels/src/filter/stars/__tests__/StarsFilter.test.js
+++ b/app/hotels/src/filter/stars/__tests__/StarsFilter.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import StarsFilter from '../StarsFilter';
 

--- a/app/hotels/src/filter/stars/__tests__/StarsPopup.test.js
+++ b/app/hotels/src/filter/stars/__tests__/StarsPopup.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import StarsPopup from '../StarsPopup';
 

--- a/app/hotels/src/gallery/GalleryGrid.js
+++ b/app/hotels/src/gallery/GalleryGrid.js
@@ -8,7 +8,7 @@ import {
   Device,
   type OnLayout,
   StyleSheet,
-} from '@kiwicom/react-native-app-shared';
+} from '@kiwicom/mobile-shared';
 
 import GalleryGridTile from './GalleryGridTile';
 import PhotosStripe from './PhotosStripe';

--- a/app/hotels/src/gallery/GalleryGridTile.js
+++ b/app/hotels/src/gallery/GalleryGridTile.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { NetworkImage, Touchable } from '@kiwicom/react-native-app-shared';
+import { NetworkImage, Touchable } from '@kiwicom/mobile-shared';
 
 type Props = {|
   onTilePress: (imageIndex: number) => void,

--- a/app/hotels/src/gallery/PhotosStripe.js
+++ b/app/hotels/src/gallery/PhotosStripe.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { View, Platform } from 'react-native';
 import Swiper from 'react-native-swiper';
-import { StyleSheet, NetworkImage } from '@kiwicom/react-native-app-shared';
+import { StyleSheet, NetworkImage } from '@kiwicom/mobile-shared';
 
 import PhotosStripeHeader from './PhotosStripeHeader';
 

--- a/app/hotels/src/gallery/PhotosStripeHeader.js
+++ b/app/hotels/src/gallery/PhotosStripeHeader.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { Text, StyleSheet, Touchable } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Text, StyleSheet, Touchable } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 type Props = {|
   photoNumber: number,

--- a/app/hotels/src/gallery/__tests__/PhotosStripeHeader.test.js
+++ b/app/hotels/src/gallery/__tests__/PhotosStripeHeader.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import PhotosStripeHeader from '../PhotosStripeHeader';
 

--- a/app/hotels/src/map/Address.js
+++ b/app/hotels/src/map/Address.js
@@ -4,13 +4,8 @@ import * as React from 'react';
 import idx from 'idx';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
-import {
-  Color,
-  Icon,
-  StyleSheet,
-  Text,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Color, Icon, StyleSheet, Text } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import type { Address_address } from './__generated__/Address_address.graphql';
 

--- a/app/hotels/src/map/BottomSheetHandle.js
+++ b/app/hotels/src/map/BottomSheetHandle.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { StyleSheet, Color } from '@kiwicom/react-native-app-shared';
+import { StyleSheet, Color } from '@kiwicom/mobile-shared';
 
 const styles = StyleSheet.create({
   handle: {

--- a/app/hotels/src/map/HotelDetailPreview.js
+++ b/app/hotels/src/map/HotelDetailPreview.js
@@ -9,8 +9,8 @@ import {
   Color,
   Price,
   Text,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 import idx from 'idx';
 
 import type { HotelDetailPreview_availability } from './__generated__/HotelDetailPreview_availability.graphql';

--- a/app/hotels/src/map/allHotels/AllHotelsMap.js
+++ b/app/hotels/src/map/allHotels/AllHotelsMap.js
@@ -3,13 +3,13 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { graphql } from 'react-relay';
-import { PublicApiRenderer } from '@kiwicom/react-native-app-relay';
+import { PublicApiRenderer } from '@kiwicom/mobile-relay';
 import {
   StyleSheet,
   AdaptableLayout,
   AppStateChange,
-} from '@kiwicom/react-native-app-shared';
-import { connect } from '@kiwicom/react-native-app-redux';
+} from '@kiwicom/mobile-shared';
+import { connect } from '@kiwicom/mobile-redux';
 
 import MapScreen from './MapScreen';
 import FilterStripe from '../../filter/FilterStripe';

--- a/app/hotels/src/map/allHotels/HotelSwipeList.js
+++ b/app/hotels/src/map/allHotels/HotelSwipeList.js
@@ -9,9 +9,9 @@ import {
   Device,
   StyleSheet,
   AdaptableLayout,
-} from '@kiwicom/react-native-app-shared';
+} from '@kiwicom/mobile-shared';
 import idx from 'idx';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import HotelSwipeItem from './HotelSwipeItem';
 import Address from '../Address';

--- a/app/hotels/src/map/allHotels/MapScreen.js
+++ b/app/hotels/src/map/allHotels/MapScreen.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { createFragmentContainer, graphql } from 'react-relay';
 import idx from 'idx';
-import { StyleSheet } from '@kiwicom/react-native-app-shared';
+import { StyleSheet } from '@kiwicom/mobile-shared';
 
 import MapView from './MapView';
 import HotelSwipeList from './HotelSwipeList';

--- a/app/hotels/src/map/allHotels/MapView.js
+++ b/app/hotels/src/map/allHotels/MapView.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import MapView from 'react-native-maps';
 import { orderByDistance, getBounds } from 'geolib';
-import { StyleSheet } from '@kiwicom/react-native-app-shared';
+import { StyleSheet } from '@kiwicom/mobile-shared';
 
 import PriceMarker from './PriceMarker';
 import type { MapView as MapViewData } from './__generated__/MapView.graphql';

--- a/app/hotels/src/map/allHotels/PriceMarker.js
+++ b/app/hotels/src/map/allHotels/PriceMarker.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
-import { Color, Price, StyleSheet } from '@kiwicom/react-native-app-shared';
+import { Color, Price, StyleSheet } from '@kiwicom/mobile-shared';
 
 import type { PriceMarker as PriceMarkerData } from './__generated__/PriceMarker.graphql';
 

--- a/app/hotels/src/map/singleHotel/AdditionalInfo.js
+++ b/app/hotels/src/map/singleHotel/AdditionalInfo.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import idx from 'idx';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
-import { StyleSheet } from '@kiwicom/react-native-app-shared';
+import { StyleSheet } from '@kiwicom/mobile-shared';
 
 import BottomSheet from './BottomSheet';
 import HotelDetailPreview from '../HotelDetailPreview';

--- a/app/hotels/src/map/singleHotel/BottomSheet.js
+++ b/app/hotels/src/map/singleHotel/BottomSheet.js
@@ -7,7 +7,7 @@ import {
   Device,
   AdaptableLayout,
   StyleSheet,
-} from '@kiwicom/react-native-app-shared';
+} from '@kiwicom/mobile-shared';
 
 import { openHeight, closedHeight } from '../bottomSheetDimensions';
 

--- a/app/hotels/src/map/singleHotel/MapView.js
+++ b/app/hotels/src/map/singleHotel/MapView.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import idx from 'idx';
 import { createFragmentContainer, graphql } from 'react-relay';
 import NativeMapView from 'react-native-maps';
-import { DropMarker, StyleSheet } from '@kiwicom/react-native-app-shared';
+import { DropMarker, StyleSheet } from '@kiwicom/mobile-shared';
 
 import type { MapView_hotel } from './__generated__/MapView_hotel.graphql';
 

--- a/app/hotels/src/map/singleHotel/SingleHotelMapScreen.js
+++ b/app/hotels/src/map/singleHotel/SingleHotelMapScreen.js
@@ -4,8 +4,8 @@ import * as React from 'react';
 import idx from 'idx';
 import { View } from 'react-native';
 import { graphql } from 'react-relay';
-import { PublicApiRenderer } from '@kiwicom/react-native-app-relay';
-import { StyleSheet } from '@kiwicom/react-native-app-shared';
+import { PublicApiRenderer } from '@kiwicom/mobile-relay';
+import { StyleSheet } from '@kiwicom/mobile-shared';
 
 import type { AvailableHotelSearchInput } from '../../singleHotel/AvailableHotelSearchInput';
 import MapView from './MapView';

--- a/app/hotels/src/navigation/NavigationStack.js
+++ b/app/hotels/src/navigation/NavigationStack.js
@@ -4,7 +4,7 @@ import {
   StackNavigator,
   StackNavigatorOptions,
   type NavigationType,
-} from '@kiwicom/react-native-app-navigation';
+} from '@kiwicom/mobile-navigation';
 
 import AllHotelsMapStack from './allHotelsMap/AllHotelsMapStack';
 import AllHotelsStack from './allHotels/AllHotelsStack';

--- a/app/hotels/src/navigation/allHotels/AllHotelsNavigationScreen.js
+++ b/app/hotels/src/navigation/allHotels/AllHotelsNavigationScreen.js
@@ -3,12 +3,9 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { HeaderBackButton } from 'react-navigation';
-import { StyleSheet, AdaptableLayout } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
-import {
-  HeaderTitle,
-  type NavigationType,
-} from '@kiwicom/react-native-app-navigation';
+import { StyleSheet, AdaptableLayout } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
+import { HeaderTitle, type NavigationType } from '@kiwicom/mobile-navigation';
 
 import AllHotels from '../../allHotels/AllHotels';
 import AllHotelsMap from '../../map/allHotels/AllHotelsMap';

--- a/app/hotels/src/navigation/allHotels/AllHotelsStack.js
+++ b/app/hotels/src/navigation/allHotels/AllHotelsStack.js
@@ -3,7 +3,7 @@
 import {
   StackNavigator,
   StackNavigatorOptions,
-} from '@kiwicom/react-native-app-navigation';
+} from '@kiwicom/mobile-navigation';
 import { withMappedNavigationAndConfigProps as withMappedProps } from 'react-navigation-props-mapper';
 
 import AllHotelsNavigationScreen from './AllHotelsNavigationScreen';

--- a/app/hotels/src/navigation/allHotels/GuestsModalScreen.js
+++ b/app/hotels/src/navigation/allHotels/GuestsModalScreen.js
@@ -1,18 +1,10 @@
 // @flow
 
 import * as React from 'react';
-import {
-  type NavigationType,
-  HeaderTitle,
-} from '@kiwicom/react-native-app-navigation';
-import {
-  Touchable,
-  Text,
-  StyleSheet,
-  Color,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
-import { connect } from '@kiwicom/react-native-app-redux';
+import { type NavigationType, HeaderTitle } from '@kiwicom/mobile-navigation';
+import { Touchable, Text, StyleSheet, Color } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
+import { connect } from '@kiwicom/mobile-redux';
 
 import type { HotelsReducerState } from '../../HotelsReducer';
 import type {

--- a/app/hotels/src/navigation/allHotels/LocationPickerScreen.js
+++ b/app/hotels/src/navigation/allHotels/LocationPickerScreen.js
@@ -1,17 +1,9 @@
 // @flow
 
 import * as React from 'react';
-import {
-  Text,
-  Touchable,
-  StyleSheet,
-  Color,
-} from '@kiwicom/react-native-app-shared';
-import {
-  type NavigationType,
-  HeaderTitle,
-} from '@kiwicom/react-native-app-navigation';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Text, Touchable, StyleSheet, Color } from '@kiwicom/mobile-shared';
+import { type NavigationType, HeaderTitle } from '@kiwicom/mobile-navigation';
+import { Translation } from '@kiwicom/mobile-localization';
 import idx from 'idx';
 
 import LocationPicker from '../../allHotels/searchForm/locationPicker/LocationPicker';

--- a/app/hotels/src/navigation/allHotels/MapHeaderButton.android.js
+++ b/app/hotels/src/navigation/allHotels/MapHeaderButton.android.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { HeaderRightButton } from '@kiwicom/react-native-app-shared';
+import { HeaderRightButton } from '@kiwicom/mobile-shared';
 import RNTooltips from 'react-native-tooltips';
 
 type Props = {|

--- a/app/hotels/src/navigation/allHotels/MapHeaderButton.ios.js
+++ b/app/hotels/src/navigation/allHotels/MapHeaderButton.ios.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { HeaderRightButton } from '@kiwicom/react-native-app-shared';
+import { HeaderRightButton } from '@kiwicom/mobile-shared';
 
 type Props = {|
   onPress: () => void,

--- a/app/hotels/src/navigation/allHotelsMap/AllHotelsMapNavigationScreen.js
+++ b/app/hotels/src/navigation/allHotelsMap/AllHotelsMapNavigationScreen.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { type NavigationType } from '@kiwicom/react-native-app-navigation';
+import { type NavigationType } from '@kiwicom/mobile-navigation';
 import { HeaderBackButton } from 'react-navigation';
 
 import AllHotelsMap from '../../map/allHotels/AllHotelsMap';

--- a/app/hotels/src/navigation/allHotelsMap/AllHotelsMapStack.js
+++ b/app/hotels/src/navigation/allHotelsMap/AllHotelsMapStack.js
@@ -6,8 +6,8 @@ import {
   HeaderTitle,
   StackNavigator,
   StackNavigatorOptions,
-} from '@kiwicom/react-native-app-navigation';
-import { Translation } from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-navigation';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import AllHotelsMapNavigationScreen from './AllHotelsMapNavigationScreen';
 

--- a/app/hotels/src/navigation/singleHotel/AdditionalPropsInjector.js
+++ b/app/hotels/src/navigation/singleHotel/AdditionalPropsInjector.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { type NavigationType } from '@kiwicom/react-native-app-navigation';
+import { type NavigationType } from '@kiwicom/mobile-navigation';
 
 type InjectorProps = {|
   navigation: NavigationType,

--- a/app/hotels/src/navigation/singleHotel/SingleHotelStack.js
+++ b/app/hotels/src/navigation/singleHotel/SingleHotelStack.js
@@ -8,9 +8,9 @@ import {
   StackNavigator,
   StackNavigatorOptions,
   createTransparentHeaderStyle,
-} from '@kiwicom/react-native-app-navigation';
-import { Translation } from '@kiwicom/react-native-app-localization';
-import { Device } from '@kiwicom/react-native-app-shared';
+} from '@kiwicom/mobile-navigation';
+import { Translation } from '@kiwicom/mobile-localization';
+import { Device } from '@kiwicom/mobile-shared';
 
 import SingleHotelNavigationScreen from './SingleHotelNavigationScreen';
 import SingleHotelMapNavigationScreen from './SingleHotelMapNavigationScreen';

--- a/app/hotels/src/search/SearchQueryHelpers.js
+++ b/app/hotels/src/search/SearchQueryHelpers.js
@@ -1,7 +1,7 @@
 // @flow
 
 import idx from 'idx';
-import { DateFormatter } from '@kiwicom/react-native-app-localization';
+import { DateFormatter } from '@kiwicom/mobile-localization';
 
 import { sanitizeDate } from '../GraphQLSanitizers';
 import type { Coordinates } from '../CoordinatesType';

--- a/app/hotels/src/search/__tests__/SearchQueryHelpers.test.js
+++ b/app/hotels/src/search/__tests__/SearchQueryHelpers.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { DateFormatter } from '@kiwicom/react-native-app-localization';
+import { DateFormatter } from '@kiwicom/mobile-localization';
 
 import {
   getSearchQueryParams,

--- a/app/hotels/src/singleHotel/HotelDetailScreen.js
+++ b/app/hotels/src/singleHotel/HotelDetailScreen.js
@@ -8,7 +8,7 @@ import {
   Logger,
   AdaptableLayout,
   StyleSheet,
-} from '@kiwicom/react-native-app-shared';
+} from '@kiwicom/mobile-shared';
 import { createFragmentContainer, graphql } from 'react-relay';
 import idx from 'idx';
 

--- a/app/hotels/src/singleHotel/PaymentScreen.js
+++ b/app/hotels/src/singleHotel/PaymentScreen.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { Platform } from 'react-native';
-import { WebView, Logger } from '@kiwicom/react-native-app-shared';
-import { DateFormatter } from '@kiwicom/react-native-app-localization';
+import { WebView, Logger } from '@kiwicom/mobile-shared';
+import { DateFormatter } from '@kiwicom/mobile-localization';
 import querystring from 'querystring';
 
 import { sanitizeDate } from '../GraphQLSanitizers';

--- a/app/hotels/src/singleHotel/bookNow/BookNow.js
+++ b/app/hotels/src/singleHotel/bookNow/BookNow.js
@@ -3,12 +3,7 @@
 import * as React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { View } from 'react-native';
-import {
-  StyleSheet,
-  Color,
-  Touchable,
-  Price,
-} from '@kiwicom/react-native-app-shared';
+import { StyleSheet, Color, Touchable, Price } from '@kiwicom/mobile-shared';
 import idx from 'idx';
 
 import BookNowText from './BookNowText';

--- a/app/hotels/src/singleHotel/bookNow/BookNowText.js
+++ b/app/hotels/src/singleHotel/bookNow/BookNowText.js
@@ -6,8 +6,8 @@ import {
   StyleSheet,
   ButtonText,
   type StylePropType,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 const styles = StyleSheet.create({
   priceWrapper: {

--- a/app/hotels/src/singleHotel/bookNow/__tests__/BookNow.test.js
+++ b/app/hotels/src/singleHotel/bookNow/__tests__/BookNow.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import { BookNow } from '../BookNow';
 

--- a/app/hotels/src/singleHotel/brandLabel/BrandLabel.js
+++ b/app/hotels/src/singleHotel/brandLabel/BrandLabel.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View, Image } from 'react-native';
-import { StyleSheet } from '@kiwicom/react-native-app-shared';
+import { StyleSheet } from '@kiwicom/mobile-shared';
 
 import brandImage from './bookingLogo.png';
 

--- a/app/hotels/src/singleHotel/galleryButton/GalleryButton.js
+++ b/app/hotels/src/singleHotel/galleryButton/GalleryButton.js
@@ -2,13 +2,9 @@
 
 import * as React from 'react';
 import { Image, View } from 'react-native';
-import {
-  StyleSheet,
-  Text,
-  type StylePropType,
-} from '@kiwicom/react-native-app-shared';
+import { StyleSheet, Text, type StylePropType } from '@kiwicom/mobile-shared';
 import idx from 'idx';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import icon from './gallery-icon.png';
 

--- a/app/hotels/src/singleHotel/header/Header.js
+++ b/app/hotels/src/singleHotel/header/Header.js
@@ -10,10 +10,10 @@ import {
   Touchable,
   AdaptableLayout,
   Device,
-} from '@kiwicom/react-native-app-shared';
+} from '@kiwicom/mobile-shared';
 import idx from 'idx';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import GalleryButton from '../galleryButton/GalleryButton';
 import Rating from './Rating';

--- a/app/hotels/src/singleHotel/header/Rating.js
+++ b/app/hotels/src/singleHotel/header/Rating.js
@@ -1,11 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { Stars } from '@kiwicom/react-native-app-shared';
-import {
-  Translation,
-  TranslationFragment,
-} from '@kiwicom/react-native-app-localization';
+import { Stars } from '@kiwicom/mobile-shared';
+import { Translation, TranslationFragment } from '@kiwicom/mobile-localization';
 
 type Props = {|
   stars?: ?number,

--- a/app/hotels/src/singleHotel/hotelInformation/HotelInformation.js
+++ b/app/hotels/src/singleHotel/hotelInformation/HotelInformation.js
@@ -3,11 +3,7 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { createFragmentContainer, graphql } from 'react-relay';
-import {
-  AdaptableLayout,
-  StyleSheet,
-  Color,
-} from '@kiwicom/react-native-app-shared';
+import { AdaptableLayout, StyleSheet, Color } from '@kiwicom/mobile-shared';
 
 import Location from './location/Location';
 import Description from './description/Description';

--- a/app/hotels/src/singleHotel/hotelInformation/description/Description.js
+++ b/app/hotels/src/singleHotel/hotelInformation/description/Description.js
@@ -10,8 +10,8 @@ import {
   StyleSheet,
   AdaptableLayout,
   ReadMore,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import type { Description_hotel } from './__generated__/Description_hotel.graphql';
 import Facilities from './Facilities';

--- a/app/hotels/src/singleHotel/hotelInformation/description/Facilities.js
+++ b/app/hotels/src/singleHotel/hotelInformation/description/Facilities.js
@@ -10,11 +10,8 @@ import {
   AdaptableBadge,
   Text,
   Touchable,
-} from '@kiwicom/react-native-app-shared';
-import {
-  Translation,
-  TranslationFragment,
-} from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-shared';
+import { Translation, TranslationFragment } from '@kiwicom/mobile-localization';
 
 import type { Facilities_facilities } from './__generated__/Facilities_facilities.graphql';
 

--- a/app/hotels/src/singleHotel/hotelInformation/location/Location.js
+++ b/app/hotels/src/singleHotel/hotelInformation/location/Location.js
@@ -10,10 +10,10 @@ import {
   Text,
   Touchable,
   Color,
-} from '@kiwicom/react-native-app-shared';
+} from '@kiwicom/mobile-shared';
 import idx from 'idx';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import gradient from './white-to-alpha-horizontal.png';
 import type { Location_hotel } from './__generated__/Location_hotel.graphql';

--- a/app/hotels/src/singleHotel/index.js
+++ b/app/hotels/src/singleHotel/index.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { graphql } from 'react-relay';
-import { PublicApiRenderer } from '@kiwicom/react-native-app-relay';
-import { MapLocaleToLanguageQuery } from '@kiwicom/react-native-app-localization';
+import { PublicApiRenderer } from '@kiwicom/mobile-relay';
+import { MapLocaleToLanguageQuery } from '@kiwicom/mobile-localization';
 
 import HotelDetailScreen from './HotelDetailScreen';
 import type { Image } from '../gallery/GalleryGrid';

--- a/app/hotels/src/singleHotel/roomList/BeddingInfo.js
+++ b/app/hotels/src/singleHotel/roomList/BeddingInfo.js
@@ -9,8 +9,8 @@ import {
   TextIcon,
   Icon,
   Color,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 import idx from 'idx';
 
 import type { BeddingInfo_room } from './__generated__/BeddingInfo_room.graphql';

--- a/app/hotels/src/singleHotel/roomList/RoomBadges.js
+++ b/app/hotels/src/singleHotel/roomList/RoomBadges.js
@@ -3,11 +3,7 @@
 import * as React from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import idx from 'idx';
-import {
-  AdaptableBadge,
-  StyleSheet,
-  TextIcon,
-} from '@kiwicom/react-native-app-shared';
+import { AdaptableBadge, StyleSheet, TextIcon } from '@kiwicom/mobile-shared';
 
 import type { RoomBadges_availableRoom as RoomBadgesTypes } from './__generated__/RoomBadges_availableRoom.graphql';
 

--- a/app/hotels/src/singleHotel/roomList/RoomDescription.js
+++ b/app/hotels/src/singleHotel/roomList/RoomDescription.js
@@ -4,13 +4,8 @@ import * as React from 'react';
 import { View } from 'react-native';
 import { createFragmentContainer, graphql } from 'react-relay';
 import idx from 'idx';
-import {
-  Text,
-  StyleSheet,
-  Color,
-  ReadMore,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Text, StyleSheet, Color, ReadMore } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import type { RoomDescription_room as RoomDescriptionType } from './__generated__/RoomDescription_room.graphql';
 

--- a/app/hotels/src/singleHotel/roomList/RoomImage.js
+++ b/app/hotels/src/singleHotel/roomList/RoomImage.js
@@ -2,11 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import {
-  Touchable,
-  NetworkImage,
-  StyleSheet,
-} from '@kiwicom/react-native-app-shared';
+import { Touchable, NetworkImage, StyleSheet } from '@kiwicom/mobile-shared';
 
 import GalleryButton from '../galleryButton/GalleryButton';
 

--- a/app/hotels/src/singleHotel/roomList/RoomList.js
+++ b/app/hotels/src/singleHotel/roomList/RoomList.js
@@ -3,8 +3,8 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { StyleSheet, Text, Color } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { StyleSheet, Text, Color } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import RoomRow from './RoomRow';
 import type { RoomList as RoomListType } from './__generated__/RoomList.graphql';

--- a/app/hotels/src/singleHotel/roomList/RoomRow.js
+++ b/app/hotels/src/singleHotel/roomList/RoomRow.js
@@ -7,7 +7,7 @@ import {
   SimpleCard,
   StyleSheet,
   AdaptableLayout,
-} from '@kiwicom/react-native-app-shared';
+} from '@kiwicom/mobile-shared';
 import { createFragmentContainer, graphql } from 'react-relay';
 
 import RoomPicker from '../roomPicker/RoomPicker';

--- a/app/hotels/src/singleHotel/roomList/RoomRowTitle.js
+++ b/app/hotels/src/singleHotel/roomList/RoomRowTitle.js
@@ -1,14 +1,9 @@
 // @flow
 
 import * as React from 'react';
-import {
-  Text,
-  TextIcon,
-  StyleSheet,
-  Color,
-} from '@kiwicom/react-native-app-shared';
+import { Text, TextIcon, StyleSheet, Color } from '@kiwicom/mobile-shared';
 import { createFragmentContainer, graphql } from 'react-relay';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 import idx from 'idx';
 
 import type { RoomRowTitle_room as RoomRowTitleType } from './__generated__/RoomRowTitle_room.graphql';

--- a/app/hotels/src/singleHotel/roomList/__tests__/RoomBadges.test.js
+++ b/app/hotels/src/singleHotel/roomList/__tests__/RoomBadges.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import { RoomBadges } from '../RoomBadges';
 

--- a/app/hotels/src/singleHotel/roomList/__tests__/RoomDescription.test.js
+++ b/app/hotels/src/singleHotel/roomList/__tests__/RoomDescription.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import { RoomDescription } from '../RoomDescription';
 

--- a/app/hotels/src/singleHotel/roomPicker/RoomPicker.js
+++ b/app/hotels/src/singleHotel/roomPicker/RoomPicker.js
@@ -9,8 +9,8 @@ import {
   Touchable,
   ButtonText,
   Color,
-} from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 type Props = {|
   price: number | null,

--- a/app/hotels/src/singleHotel/roomPicker/__tests__/RoomPicker.test.js
+++ b/app/hotels/src/singleHotel/roomPicker/__tests__/RoomPicker.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import RoomPicker from '../RoomPicker';
 

--- a/app/localization/package.json
+++ b/app/localization/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kiwicom/react-native-app-localization",
+  "name": "@kiwicom/mobile-localization",
   "version": "0.0.0",
   "private": false,
   "main": "index.js",

--- a/app/localization/src/Translation.js
+++ b/app/localization/src/Translation.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { NativeModules } from 'react-native';
-import { Text } from '@kiwicom/react-native-app-shared';
+import { Text } from '@kiwicom/mobile-shared';
 
 import DefaultVocabulary, { type TranslationKeys } from './DefaultVocabulary';
 import CaseTransform, {

--- a/app/localization/src/__tests__/TranslationFragment.test.js
+++ b/app/localization/src/__tests__/TranslationFragment.test.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 import testRenderer from 'react-test-renderer';
-import { Text } from '@kiwicom/react-native-app-shared';
+import { Text } from '@kiwicom/mobile-shared';
 
 import Translation from '../Translation';
 import TranslationFragment from '../TranslationFragment';

--- a/app/navigation/index.js
+++ b/app/navigation/index.js
@@ -3,13 +3,8 @@
 import * as React from 'react';
 import { Platform, StatusBar } from 'react-native';
 import ReactNavigation from 'react-navigation';
-import {
-  Color,
-  Device,
-  Text,
-  StyleSheet,
-} from '@kiwicom/react-native-app-shared';
-import type { TranslationType } from '@kiwicom/react-native-app-localization';
+import { Color, Device, Text, StyleSheet } from '@kiwicom/mobile-shared';
+import type { TranslationType } from '@kiwicom/mobile-localization';
 
 const createNavigationOptions = () => {
   const navigationOptions: Object = {

--- a/app/navigation/package.json
+++ b/app/navigation/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@kiwicom/react-native-app-navigation",
+  "name": "@kiwicom/mobile-navigation",
   "version": "0.0.0",
   "private": true,
   "main": "index.js",
   "dependencies": {
-    "@kiwicom/react-native-app-localization": "^0",
+    "@kiwicom/mobile-localization": "^0",
     "react-navigation": "^1.5.11",
     "react-navigation-props-mapper": "^0.1.2"
   }

--- a/app/playground/Playground.js
+++ b/app/playground/Playground.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { StyleSheet, Text } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { StyleSheet, Text } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import PlaygroundRenderer from './PlaygroundRenderer';
 // Import component tests you want to show in the Playground here:

--- a/app/playground/package.json
+++ b/app/playground/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kiwicom/react-native-app-playground",
+  "name": "@kiwicom/mobile-playground",
   "version": "0.0.0",
   "private": true,
   "main": "index.js"

--- a/app/redux/package.json
+++ b/app/redux/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kiwicom/react-native-app-redux",
+  "name": "@kiwicom/mobile-redux",
   "version": "0.0.0",
   "private": true,
   "main": "index.js",

--- a/app/relay/package.json
+++ b/app/relay/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kiwicom/react-native-app-relay",
+  "name": "@kiwicom/mobile-relay",
   "version": "0.0.0",
   "private": true,
   "main": "index.js",

--- a/app/relay/src/QueryRenderer.js
+++ b/app/relay/src/QueryRenderer.js
@@ -6,7 +6,7 @@ import {
   FullPageLoading,
   GeneralError,
   PartialFailure,
-} from '@kiwicom/react-native-app-shared';
+} from '@kiwicom/mobile-shared';
 
 import PublicEnvironment from './PublicEnvironment';
 import PrivateEnvironment from './PrivateEnvironment';

--- a/app/shared/package.json
+++ b/app/shared/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@kiwicom/react-native-app-shared",
+  "name": "@kiwicom/mobile-shared",
   "version": "0.0.0",
   "private": true,
   "main": "index.js",
   "dependencies": {
-    "@kiwicom/react-native-app-accessibility": "^0",
-    "@kiwicom/react-native-app-localization": "^0",
+    "@kiwicom/mobile-accessibility": "^0",
+    "@kiwicom/mobile-localization": "^0",
     "@kiwicom/react-native-native-modules": "^0.1.24",
     "@ptomasroos/react-native-multi-slider": "^0.0.12",
     "react-native-image-progress": "^1.1.0",
@@ -13,6 +13,6 @@
     "react-native-vector-icons": "^4.6.0"
   },
   "devDependencies": {
-    "@kiwicom/react-native-app-playground": "^0"
+    "@kiwicom/mobile-playground": "^0"
   }
 }

--- a/app/shared/src/Price.js
+++ b/app/shared/src/Price.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import CurrencyFormatter from './currency/CurrencyFormatter';
 import Text from './Text';

--- a/app/shared/src/ReadMore.js
+++ b/app/shared/src/ReadMore.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import OriginalReadMore from 'react-native-read-more-text'; // eslint-disable-line no-restricted-imports
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import Text from './Text';
 import Touchable from './Touchable';

--- a/app/shared/src/Touchable.js
+++ b/app/shared/src/Touchable.js
@@ -8,7 +8,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import type { AccessibilityProps } from '@kiwicom/react-native-app-accessibility';
+import type { AccessibilityProps } from '@kiwicom/mobile-accessibility';
 
 import { type StylePropType } from '../types/Styles';
 

--- a/app/shared/src/__tests__/ReadMore.test.js
+++ b/app/shared/src/__tests__/ReadMore.test.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import ReadMore from '../ReadMore';
 

--- a/app/shared/src/__tests__/Text.test.js
+++ b/app/shared/src/__tests__/Text.test.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import Text from '../Text';
 

--- a/app/shared/src/__tests__/Touchable.ripple.test.js
+++ b/app/shared/src/__tests__/Touchable.ripple.test.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import Touchable from '../Touchable';
 

--- a/app/shared/src/__tests__/Touchable.test.js
+++ b/app/shared/src/__tests__/Touchable.test.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { View } from 'react-native';
 import ShallowRenderer from 'react-test-renderer/shallow';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import Touchable from '../Touchable';
 

--- a/app/shared/src/badge/AdaptableBadge.js
+++ b/app/shared/src/badge/AdaptableBadge.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { Translation } from '@kiwicom/react-native-app-localization';
-import type { StylePropType } from '@kiwicom/react-native-app-shared';
+import { Translation } from '@kiwicom/mobile-localization';
+import type { StylePropType } from '@kiwicom/mobile-shared';
 
 import Text from '../Text';
 import Color from '../Color';

--- a/app/shared/src/badge/__tests__/AdaptableBadge.test.js
+++ b/app/shared/src/badge/__tests__/AdaptableBadge.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import AdaptableBadge from '../AdaptableBadge';
 

--- a/app/shared/src/bottomSheet/BottomSheet.js
+++ b/app/shared/src/bottomSheet/BottomSheet.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { LayoutAnimation } from '@kiwicom/react-native-app-shared';
+import { LayoutAnimation } from '@kiwicom/mobile-shared';
 
 import StyleSheet from '../PlatformStyleSheet';
 import VerticalSwipeResponder from '../view/VerticalSwipeResponder';

--- a/app/shared/src/buttons/Button.js
+++ b/app/shared/src/buttons/Button.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import type { TranslationType } from '@kiwicom/react-native-app-localization';
+import type { TranslationType } from '@kiwicom/mobile-localization';
 
 import Color from '../Color';
 import Touchable from '../Touchable';

--- a/app/shared/src/buttons/ButtonText.js
+++ b/app/shared/src/buttons/ButtonText.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import { Platform } from 'react-native';
-import type { TranslationType } from '@kiwicom/react-native-app-localization';
+import type { TranslationType } from '@kiwicom/mobile-localization';
 
 import Text from '../Text';
 import type { StylePropType } from '../../types/Styles';

--- a/app/shared/src/buttons/IncrementDecrementButtons.js
+++ b/app/shared/src/buttons/IncrementDecrementButtons.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import Text from '../Text';
 import Color from '../Color';

--- a/app/shared/src/buttons/LinkButton.js
+++ b/app/shared/src/buttons/LinkButton.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import type { TranslationType } from '@kiwicom/react-native-app-localization';
+import type { TranslationType } from '@kiwicom/mobile-localization';
 
 import Color from '../Color';
 import Touchable from '../Touchable';

--- a/app/shared/src/buttons/__tests__/Button.test.js
+++ b/app/shared/src/buttons/__tests__/Button.test.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import Button from '../Button';
 

--- a/app/shared/src/buttons/__tests__/ButtonText.test.js
+++ b/app/shared/src/buttons/__tests__/ButtonText.test.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { Platform } from 'react-native';
 import ShallowRenderer from 'react-test-renderer/shallow';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import ButtonText from '../ButtonText';
 

--- a/app/shared/src/buttons/__tests__/IncrementDecrementButtons.test.js
+++ b/app/shared/src/buttons/__tests__/IncrementDecrementButtons.test.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import renderer from 'react-test-renderer';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import IncrementDecrementButtons from '../IncrementDecrementButtons';
 import Touchable from '../../Touchable';

--- a/app/shared/src/cards/__tests__/SimpleCard.test.js
+++ b/app/shared/src/cards/__tests__/SimpleCard.test.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import SimpleCard from '../SimpleCard';
 

--- a/app/shared/src/datetime/Date.js
+++ b/app/shared/src/datetime/Date.js
@@ -1,10 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import {
-  Translation,
-  DateFormatter,
-} from '@kiwicom/react-native-app-localization';
+import { Translation, DateFormatter } from '@kiwicom/mobile-localization';
 
 import Text from '../Text';
 import StyleSheet from '../PlatformStyleSheet';

--- a/app/shared/src/datetime/DateTime.js
+++ b/app/shared/src/datetime/DateTime.js
@@ -1,10 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import {
-  Translation,
-  DateFormatter,
-} from '@kiwicom/react-native-app-localization';
+import { Translation, DateFormatter } from '@kiwicom/mobile-localization';
 
 type Props = {|
   dateTime: ?string,

--- a/app/shared/src/errors/GeneralError.js
+++ b/app/shared/src/errors/GeneralError.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import CenteredView from '../view/CenteredView';
 import Color from '../Color';

--- a/app/shared/src/errors/PartialFailure.js
+++ b/app/shared/src/errors/PartialFailure.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { Touchable } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Touchable } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import StyleSheet from '../PlatformStyleSheet';
 import Color from '../Color';

--- a/app/shared/src/errors/__tests__/PartialFailure.test.js
+++ b/app/shared/src/errors/__tests__/PartialFailure.test.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import renderer from 'react-test-renderer';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import PartialFailure from '../PartialFailure';
 

--- a/app/shared/src/forms/AgePicker.js
+++ b/app/shared/src/forms/AgePicker.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { Picker, View } from 'react-native';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import BarPopup from '../popup/BarPopup';
 import StyleSheet from '../PlatformStyleSheet';

--- a/app/shared/src/forms/NumberControl.js
+++ b/app/shared/src/forms/NumberControl.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import Text from '../Text';
 import IncrementDecrementButtons from '../buttons/IncrementDecrementButtons';

--- a/app/shared/src/forms/Slider.js
+++ b/app/shared/src/forms/Slider.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import type { OnLayout } from '@kiwicom/react-native-app-shared';
+import type { OnLayout } from '@kiwicom/mobile-shared';
 import MultiSlider from '@ptomasroos/react-native-multi-slider';
 
 import Color from '../Color';

--- a/app/shared/src/forms/__tests__/Slider.test.js
+++ b/app/shared/src/forms/__tests__/Slider.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 
 import Slider from '../Slider';
 

--- a/app/shared/src/forms/datePicker/DatePicker.ios.js
+++ b/app/shared/src/forms/datePicker/DatePicker.ios.js
@@ -2,10 +2,7 @@
 
 import * as React from 'react';
 import { DatePickerIOS } from 'react-native';
-import {
-  Translation,
-  GetDeviceLocale,
-} from '@kiwicom/react-native-app-localization';
+import { Translation, GetDeviceLocale } from '@kiwicom/mobile-localization';
 
 import DatePickerButton from './DatePickerButton';
 import BarPopup from '../../popup/BarPopup';

--- a/app/shared/src/forms/datePicker/DatePickerButton.js
+++ b/app/shared/src/forms/datePicker/DatePickerButton.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { DateFormatter } from '@kiwicom/react-native-app-localization';
+import { DateFormatter } from '@kiwicom/mobile-localization';
 import { View } from 'react-native';
 
 import Touchable from '../../Touchable';

--- a/app/shared/src/forms/datePicker/__tests__/DatePicker.test.js
+++ b/app/shared/src/forms/datePicker/__tests__/DatePicker.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
 import MockDate from 'mockdate';
 
 import DatePicker from '../DatePicker';

--- a/app/shared/src/icons/Icon.js
+++ b/app/shared/src/icons/Icon.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
-import type { StylePropType } from '@kiwicom/react-native-app-shared';
+import type { StylePropType } from '@kiwicom/mobile-shared';
 
 import Color from '../Color';
 

--- a/app/shared/src/icons/TextIcon.js
+++ b/app/shared/src/icons/TextIcon.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { Translation } from '@kiwicom/react-native-app-localization';
-import type { StylePropType } from '@kiwicom/react-native-app-shared';
+import { Translation } from '@kiwicom/mobile-localization';
+import type { StylePropType } from '@kiwicom/mobile-shared';
 
 import Color from '../Color';
 import Text from '../Text';

--- a/app/shared/src/image/NetworkImage.js
+++ b/app/shared/src/image/NetworkImage.js
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 import Image from 'react-native-image-progress';
-import { connect } from '@kiwicom/react-native-app-redux';
-import type { StylePropType } from '@kiwicom/react-native-app-shared';
+import { connect } from '@kiwicom/mobile-redux';
+import type { StylePropType } from '@kiwicom/mobile-shared';
 
 import MissingImage from './MissingImage';
 import IconLoading from '../loaders/IconLoading';

--- a/app/shared/src/popup/BarPopup.js
+++ b/app/shared/src/popup/BarPopup.js
@@ -5,7 +5,7 @@ import { View } from 'react-native';
 import {
   Translation,
   type TranslationType,
-} from '@kiwicom/react-native-app-localization';
+} from '@kiwicom/mobile-localization';
 
 import Popup from './Popup';
 import Color from '../Color';

--- a/app/shared/src/popup/ButtonPopup.js
+++ b/app/shared/src/popup/ButtonPopup.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View } from 'react-native';
-import type { TranslationType } from '@kiwicom/react-native-app-localization';
+import type { TranslationType } from '@kiwicom/mobile-localization';
 
 import Popup from './Popup';
 import Button from '../buttons/Button';

--- a/app/shared/src/popup/Popup.js
+++ b/app/shared/src/popup/Popup.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { View, ScrollView } from 'react-native';
-import { AdaptableLayout } from '@kiwicom/react-native-app-shared';
+import { AdaptableLayout } from '@kiwicom/mobile-shared';
 
 import Modal from '../Modal';
 import StyleSheet from '../PlatformStyleSheet';

--- a/app/shared/src/popup/__tests__/ButtonPopup.test.js
+++ b/app/shared/src/popup/__tests__/ButtonPopup.test.js
@@ -3,8 +3,8 @@
 import * as React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow';
 import renderer from 'react-test-renderer';
-import { Touchable } from '@kiwicom/react-native-app-shared';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Touchable } from '@kiwicom/mobile-shared';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import ButtonPopup from '../ButtonPopup';
 

--- a/app/shared/src/popup/__tests__/ButtonPopupPlayground.test.js
+++ b/app/shared/src/popup/__tests__/ButtonPopupPlayground.test.js
@@ -1,8 +1,8 @@
 // @flow
 
 import * as React from 'react';
-import { PlaygroundRenderer } from '@kiwicom/react-native-app-playground';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { PlaygroundRenderer } from '@kiwicom/mobile-playground';
+import { Translation } from '@kiwicom/mobile-localization';
 
 import ButtonPopup from '../ButtonPopup';
 

--- a/app/shared/src/rating/Stars.js
+++ b/app/shared/src/rating/Stars.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import { Translation } from '@kiwicom/react-native-app-localization';
+import { Translation } from '@kiwicom/mobile-localization';
 
 type Props = {|
   // number of stars

--- a/app/shared/src/view/VerticalSwipeResponder.js
+++ b/app/shared/src/view/VerticalSwipeResponder.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { Animated, PanResponder } from 'react-native';
-import type { StylePropType } from '@kiwicom/react-native-app-shared';
+import type { StylePropType } from '@kiwicom/mobile-shared';
 
 import type { GestureState, PanResponderEvent } from '../../types/Events';
 


### PR DESCRIPTION
Note: only hotels package is still '@kiwicom/react-native-app-hotels'
because of backward compatibility. We are not using it internally anyway.

Closes: https://github.com/kiwicom/react-native-app/issues/490